### PR TITLE
Rc v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## unreleased
 
+## [0.1.4] - 2021-02-18
+### Changed
+- Use '/api/v1/config' instead of '/holochain-api/v1/hosted_happs' to check auth
+
 ## [0.1.3] - 2021-02-18
 ### Changed
 - Edit device name disabled and pencil icon grayed out

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "host-console",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "scripts": {
     "serve": "VUE_APP_UI_VERSION=$npm_package_version vue-cli-service serve",

--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -107,7 +107,7 @@ const HposInterface = {
 
   checkAuth: async () => {
     try {
-      await HposInterface.hostedHapps()
+      await HposInterface.settings()
     } catch (error) {
       console.log('checkAuth failed')
       return false


### PR DESCRIPTION
### Changed
- Use '/api/v1/config' instead of '/holochain-api/v1/hosted_happs' to check auth