### PR TITLE
B-03515 - hide mock storage data

### DIFF
--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -89,7 +89,11 @@ const presentHposSettings = (hposSettings) => {
 }
 
 const HposInterface = {
-  dashboard: () => hposHolochainCall({ method: 'get', path: '/dashboard' })({ duration_unit: 'DAY', amount: 1 }),
+  dashboard: async () => {
+    const dashboardData = await hposHolochainCall({ method: 'get', path: '/dashboard' })({ duration_unit: 'DAY', amount: 1 })
+    dashboardData.currentTotalStorage = '--' // currently hiding this value from the UI as it's mock data coming from the api
+    return dashboardData
+  },
 
   hostedHapps: async () => {
     const result = await hposHolochainCall({ method: 'get', path: '/hosted_happs' })({
@@ -98,7 +102,12 @@ const HposInterface = {
     })
 
     if (Array.isArray(result)) {
-      return result.filter(happ => happ.enabled).map(mergeMockHappData)
+      return result.filter(happ => happ.enabled)
+        .map(mergeMockHappData)
+        .map(happ => ({ // currently hiding storage value from the UI as it's mock data coming from the api
+          ...happ,
+          storage: '--'
+        }))
     } else {
       console.error("hosted_happs didn't return an array")
       return []

--- a/src/pages/__tests__/Dashboard.test.js
+++ b/src/pages/__tests__/Dashboard.test.js
@@ -40,7 +40,7 @@ it('shows the proper data', async () => {
         data: {
           admin: {}
         }
-      }      
+      }
     }
 
     if (path.endsWith('dashboard')) {
@@ -48,17 +48,17 @@ it('shows the proper data', async () => {
     }
 
     throw new Error (`axios mock doesn't recognise this path: ${path}`)
-  })    
+  })
 
   const { getByText, getByTestId } = render(Dashboard, {routes})
   await wait(0)
 
   await waitFor(() => getByText('39.08 s'))
-  getByText('549.8 GB')
-  getByText('4.63 TB')        
+  getByText('-- GB') // once we have real api data this should go back to '549.8 GB'
+  getByText('4.63 TB')
 
   expect(getByTestId('happ-no').textContent == hostedHappsResult.data.length)
-  expect(getByTestId('sc-no').textContent == dashboardResult.data.totalSourceChains)  
+  expect(getByTestId('sc-no').textContent == dashboardResult.data.totalSourceChains)
 
 
 })


### PR DESCRIPTION
This is a temporary change so that the UI does not present inaccurate data from the api. Once the api is returning the real usage from holochain (after the transition to sqlite is finished) we can revert these changes.