### PR TITLE
B-03952 - Design review cleanup

### DIFF
--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -3,7 +3,7 @@ const _ = require('lodash')
 // mock of normal hpos api responses
 
 const happs = [{
-  id: 1,
+  id: '1',
   name: 'HoloFuel',
   enabled: true,
   sourceChains: 110,
@@ -13,7 +13,7 @@ const happs = [{
     cpu: 49083408432
   }
 }, {
-  id: 2,
+  id: '2',
   name: 'Community',
   enabled: true,
   sourceChains: 79,
@@ -23,7 +23,7 @@ const happs = [{
     cpu: 83408432
   }
 }, {
-  id: 3,
+  id: '3',
   name: 'Elemental Chat',
   enabled: true,
   sourceChains: 34,
@@ -33,7 +33,7 @@ const happs = [{
     cpu: 595430
   }
 }, {
-  id: 4,
+  id: '4',
   name: 'A disabled happ you should never see',
   enabled: false
 }]
@@ -61,7 +61,7 @@ const data = {
       enabled: true
     },
     '/holochain-api/v1/hosted_happs': happs,
-    '/holochain-api/v1/dashboard': dashboard    
+    '/holochain-api/v1/dashboard': dashboard
   },
   put: {
     '/api/v1/config': args => args,
@@ -77,7 +77,7 @@ const data = {
 }
 
 
-function defaultResponse (method, path, body) {  
+function defaultResponse (method, path, body) {
   const pathsForMethod = data[method]
   if (pathsForMethod) {
     const response = pathsForMethod[path]

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,9 @@ export default {
 </script>
 
 <style>
+html {
+  overflow-y: scroll;
+}
 body, html {
   height: 100%;
 }

--- a/src/components/StopHostingModal.vue
+++ b/src/components/StopHostingModal.vue
@@ -14,7 +14,7 @@
       <p class='content'>This hApp has been removed from hosting.</p>
       <p class='content'>Please note it may take some time for the hApp to be fully removed from your HoloPort. Any hosting provided for storage during that time will be billed to the publisher.</p>
       <div class='buttons'>
-        <Button color='teal' @click="handleClose">Close</Button>
+        <Button color='teal' @click="closeAndGoToHapps">Close</Button>
       </div>
     </div>
   </Modal>
@@ -53,6 +53,10 @@ export default {
     confirm () {
       this.stopHostingHapp()
       this.confirmed = true
+    },
+    closeAndGoToHapps () {
+      this.handleClose()
+      this.$router.push('/happs')
     }
   }
 }

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -14,7 +14,7 @@
             </div>
             <div class="info-row grayed-out">
               <GearIcon class="gear-icon" />Hosting Preferences
-            </div>            
+            </div>
           </div>
           <div class="inner-column">
             <h3 class="inner-title">Daily Snapshot</h3>
@@ -29,8 +29,8 @@
             <div class="info-row">
               <span class="daily-label">Bandwidth</span>
               <span class="bold">{{ presentBytes(dashboard.usage.bandwidth) }}</span>
-            </div>            
-          </div>          
+            </div>
+          </div>
         </div>
       </div>
       <div class="card">
@@ -55,7 +55,7 @@
               <div class="holofuel-info-row grayed-out">{{ happ.name }}</div>
               <div class="holofuel-info-row margin-bottom grayed-out">-- HF</div>
             </div>
-          </div>          
+          </div>
           <a class='more'>
             More <RightArrowIcon class='right-arrow-icon' />
           </a>
@@ -64,7 +64,7 @@
       <div class="card">
         <h2 class="title grayed-out">
           Earnings
-          <h3 class="subtitle grayed-out">Last 7 days</h3>        
+          <h3 class="subtitle grayed-out">Last 7 days</h3>
         </h2>
         <div class="body">
           <div class="earnings-info-row grayed-out">
@@ -78,7 +78,7 @@
           <div class="earnings-info-row grayed-out">
             <span class="earnings-label">Weekly Change:</span>
             -- %
-          </div>                    
+          </div>
           <a class='more'>
             More <RightArrowIcon class='right-arrow-icon' />
           </a>
@@ -92,16 +92,16 @@
             <div class="payment-amount">-- HF</div>
             <div class="payment-details">
               <div class="">Received</div>
-              <div class="payment-happ">{{ payment.happ }}</div>              
+              <div class="payment-happ">{{ payment.happ }}</div>
             </div>
             <div class="payment-time">{{ payment.time }}</div>
-          </div>     
+          </div>
           <a class='more'>
             More <RightArrowIcon class='right-arrow-icon' />
           </a>
         </div>
       </div>
-    </div>    
+    </div>
   </PrimaryLayout>
 </template>
 
@@ -191,13 +191,16 @@ export default {
   box-shadow: 0px 4px 20px #ECEEF1;
   border-radius: 12px;
 }
+.card:last-child {
+  margin-right: 14px;
+}
 .two-columns {
   flex-basis: 69%;
 }
 .title {
   display: flex;
   align-items: center;
-  border-top-left-radius: 12px;  
+  border-top-left-radius: 12px;
   border-top-right-radius: 12px;
   background-color: rgba(176, 236, 240, 0.72);
   font-weight: bold;
@@ -308,7 +311,7 @@ export default {
   box-sizing: border-box;
   border-radius: 5px;
   width: 37px;
-  height: 37px;  
+  height: 37px;
   margin: 0 16px;
 }
 .redeem-button {
@@ -321,7 +324,7 @@ export default {
   background: rgba(8, 112, 163, 0.18);
   border-radius: 100px;
   height: 35px;
-  padding: 0 25px; 
+  padding: 0 25px;
   cursor: pointer;
   margin-bottom: 10px;
 }

--- a/src/pages/HappDetails.vue
+++ b/src/pages/HappDetails.vue
@@ -103,13 +103,11 @@ export default {
   created: async function () {
     const happs = await HposInterface.hostedHapps()
     const happId = decodeURIComponent(this.$route.params.id)
-    console.log('happs', happs)
     const happ = happs.find(({ id }) => id === happId)
     if (!happ) {
       throw new Error(`Failed to load happ with id: ${happId}`)
     }
     this.happ = happ
-    console.log('happ', happ)
   },
   methods: {
     editRates () {

--- a/src/pages/HappDetails.vue
+++ b/src/pages/HappDetails.vue
@@ -1,7 +1,7 @@
 <template>
   <PrimaryLayout :breadcrumbs="breadcrumbs">
     <div class='happ-details'>
-      <router-link class="back-link" to="/">
+      <router-link class="back-link" to="/happs">
         <LeftChevronIcon class="left-chevron" />
         Back
       </router-link>
@@ -46,11 +46,11 @@
           <div class="rate-row grayed-out">
             <div class='rate-label'>CPU</div><span class="rate-value">-- HF per Min</span>
           </div>
-          <div class="rate-row grayed-out">
-            <div class='rate-label'>Bandwidth</div><span class="rate-value">-- HF per Gb</span>
-          </div>
           <div class="rate-row rates-margin grayed-out">
             <div class='rate-label'>Storage</div><span class="rate-value">-- HF per GB</span>
+          </div>
+          <div class="rate-row grayed-out">
+            <div class='rate-label'>Bandwidth</div><span class="rate-value">-- HF per Gb</span>
           </div>
           <div class="stop-hosting-row">
             <div class="stop-hosting" @click="openHostingModal">Stop hosting</div>
@@ -103,11 +103,13 @@ export default {
   created: async function () {
     const happs = await HposInterface.hostedHapps()
     const happId = decodeURIComponent(this.$route.params.id)
+    console.log('happs', happs)
     const happ = happs.find(({ id }) => id === happId)
     if (!happ) {
       throw new Error(`Failed to load happ with id: ${happId}`)
     }
     this.happ = happ
+    console.log('happ', happ)
   },
   methods: {
     editRates () {

--- a/src/pages/HostedHapps.vue
+++ b/src/pages/HostedHapps.vue
@@ -6,7 +6,7 @@
       </div>
       <div class='filter'>
         <input v-model="filter" class="filter-input" />
-        <ExIcon v-if="filter.length > 0" @click="clearFilter" class='ex-icon' />
+        <ExIcon v-if="filter.length > 0" @click="clearFilter" size='15' class='ex-icon' />
       </div>
       <div class="label">
         Sort by:&nbsp;
@@ -101,8 +101,8 @@ export default {
 }
 .ex-icon {
   position: absolute;
-  top: 5px;
-  right: -7px;
+  top: 8px;
+  right: 6px;
 }
 .sort {
   appearance: none;

--- a/src/pages/HostedHapps.vue
+++ b/src/pages/HostedHapps.vue
@@ -94,6 +94,10 @@ export default {
 .filter-input {
   border: 1px solid #E5E5E5;
   border-radius: 5px;
+  padding: 5px;
+}
+.filter-input:focus {
+  outline-color: #313C59;
 }
 .ex-icon {
   position: absolute;

--- a/src/router.js
+++ b/src/router.js
@@ -65,6 +65,10 @@ export const routerFactory = () => {
     if (to.matched.some(record => record.meta.requiresAuth)) {
       // page only visible when logged in
 
+      // TODO: remove before merging
+      next()
+      return
+
       // isAuthed is true if the last keypair we generated was good. It persists across sessions.
       // checkHpAdminKeypair checks if we have a keypair in *this* session. If we don't, then we remove isAuthed
       // another way to handle this would be to store isAuthed in app state not local storage. Then we wouldn't need this line.

--- a/src/router.js
+++ b/src/router.js
@@ -65,10 +65,6 @@ export const routerFactory = () => {
     if (to.matched.some(record => record.meta.requiresAuth)) {
       // page only visible when logged in
 
-      // TODO: remove before merging
-      next()
-      return
-
       // isAuthed is true if the last keypair we generated was good. It persists across sessions.
       // checkHpAdminKeypair checks if we have a keypair in *this* session. If we don't, then we remove isAuthed
       // another way to handle this would be to store isAuthed in app state not local storage. Then we wouldn't need this line.


### PR DESCRIPTION
This implements a list of changes requested by @celestialhanley and @SirRobLyon around design issues.

- [X] Lana Wilson's HP alignment should be flush with the dashboard cards
- [X] clicking back on individual happ page should take user back to happs (not dashboard)
- [X] The Rates section of the individual happ should show the ordering of CPU - Storage - Bandwidth
- [x] Filter is jumping again when you click into it
- [x] reduce size and center the big x for the filter
- [X] add padding inside the filter box so words don't look so crammed
- [X] use dark grey to highlight the border around the filter box
- [X] Completion of stop hosting a happ should take the user back to the happs page where all happs are listed