### PR TITLE
Use real URL for keygen in dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "serve": "VUE_APP_UI_VERSION=$npm_package_version vue-cli-service serve",
     "start-ui-and-mock": "npm run start-mock-hpos-api & npm run serve",
-    "build": "VUE_APP_UI_VERSION=$npm_package_version USE_REAL_PUB_KEY=true vue-cli-service build",
-    "build:dev": "VUE_APP_UI_VERSION=$npm_package_version USE_REAL_PUB_KEY=true vue-cli-service build --mode development",
+    "build": "VUE_APP_UI_VERSION=$npm_package_version VUE_APP_USE_REAL_PUB_KEY=true vue-cli-service build",
+    "build:dev": "VUE_APP_UI_VERSION=$npm_package_version VUE_APP_USE_REAL_PUB_KEY=true vue-cli-service build --mode development",
     "lint": "vue-cli-service lint",
     "test": "yarn jest --watch --runInBand --detectOpenHandles",
     "test:ci": "yarn jest --runInBand --detectOpenHandles",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "serve": "VUE_APP_UI_VERSION=$npm_package_version vue-cli-service serve",
     "start-ui-and-mock": "npm run start-mock-hpos-api & npm run serve",
     "build": "VUE_APP_UI_VERSION=$npm_package_version vue-cli-service build",
+    "build:dev": "VUE_APP_UI_VERSION=$npm_package_version vue-cli-service build --mode development",
     "lint": "vue-cli-service lint",
     "test": "yarn jest --watch --runInBand --detectOpenHandles",
     "test:ci": "yarn jest --runInBand --detectOpenHandles",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "serve": "VUE_APP_UI_VERSION=$npm_package_version vue-cli-service serve",
     "start-ui-and-mock": "npm run start-mock-hpos-api & npm run serve",
-    "build": "VUE_APP_UI_VERSION=$npm_package_version vue-cli-service build",
-    "build:dev": "VUE_APP_UI_VERSION=$npm_package_version vue-cli-service build --mode development",
+    "build": "VUE_APP_UI_VERSION=$npm_package_version USE_REAL_PUB_KEY=true vue-cli-service build",
+    "build:dev": "VUE_APP_UI_VERSION=$npm_package_version USE_REAL_PUB_KEY=true vue-cli-service build --mode development",
     "lint": "vue-cli-service lint",
     "test": "yarn jest --watch --runInBand --detectOpenHandles",
     "test:ci": "yarn jest --runInBand --detectOpenHandles",

--- a/src/utils/keyManagement.js
+++ b/src/utils/keyManagement.js
@@ -2,7 +2,7 @@
 
 // Parse window.location to retrieve holoPort's HC public key (3rd level subdomain in URL)
 const getHcPubkey = () => {
-  return ((process.env.NODE_ENV === 'test')
+  return ((process.env.USE_REAL_PUB_KEY === 'true')
     ? '5m5srup6m3b2iilrsqmxu6ydp8p8cr0rdbh4wamupk3s4sxqr5'
     : window.location.hostname.split('.')[0])
 }

--- a/src/utils/keyManagement.js
+++ b/src/utils/keyManagement.js
@@ -2,7 +2,7 @@
 
 // Parse window.location to retrieve holoPort's HC public key (3rd level subdomain in URL)
 const getHcPubkey = () => {
-  return ((process.env.USE_REAL_PUB_KEY === 'true')
+  return ((process.env.VUE_APP_USE_REAL_PUB_KEY !== 'true')
     ? '5m5srup6m3b2iilrsqmxu6ydp8p8cr0rdbh4wamupk3s4sxqr5'
     : window.location.hostname.split('.')[0])
 }

--- a/src/utils/keyManagement.js
+++ b/src/utils/keyManagement.js
@@ -2,7 +2,7 @@
 
 // Parse window.location to retrieve holoPort's HC public key (3rd level subdomain in URL)
 const getHcPubkey = () => {
-  return ((process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test')
+  return ((process.env.NODE_ENV === 'test')
     ? '5m5srup6m3b2iilrsqmxu6ydp8p8cr0rdbh4wamupk3s4sxqr5'
     : window.location.hostname.split('.')[0])
 }


### PR DESCRIPTION
@robbiecarlton Would it break your dev flow if the signing only uses the hardcoded host id in test mode, not in development mode?

We could then have vue-tools enabled in deployed host console right now. (Or perhaps there's a different way to do this)