### PR TITLE
Disable "Stop Hosting" button

### DIFF
--- a/src/pages/HappDetails.vue
+++ b/src/pages/HappDetails.vue
@@ -52,7 +52,7 @@
           <div class="rate-row grayed-out">
             <div class='rate-label'>Bandwidth</div><span class="rate-value">-- HF per Gb</span>
           </div>
-          <div class="stop-hosting-row">
+          <div class="stop-hosting-row grayed-out">
             <div class="stop-hosting" @click="stopHostingHapp">Stop hosting</div>
             <div class="stop-hosting-warning">
               <AlertCircleIcon class="alert-circle-icon" />Stopping hosting of a hApp will remove it and all associated data from your HoloPort.

--- a/src/pages/HappDetails.vue
+++ b/src/pages/HappDetails.vue
@@ -53,7 +53,7 @@
             <div class='rate-label'>Bandwidth</div><span class="rate-value">-- HF per Gb</span>
           </div>
           <div class="stop-hosting-row">
-            <div class="stop-hosting" @click="openHostingModal">Stop hosting</div>
+            <div class="stop-hosting" @click="stopHostingHapp">Stop hosting</div>
             <div class="stop-hosting-warning">
               <AlertCircleIcon class="alert-circle-icon" />Stopping hosting of a hApp will remove it and all associated data from your HoloPort.
             </div>
@@ -114,6 +114,7 @@ export default {
       alert('Editing rates is not implemented in this version')
     },
     openHostingModal () {
+      // This function is not currently used but should replace the call to stopHostingHapp once we have implemented stopping hosting
       this.hostingModalVisible = true
     },
     closeHostingModal () {


### PR DESCRIPTION
This is a temporary change to not display the "Stop hosting" modal when clicking "stop hosting", as the modal currently doesn't do anything. Once stopping hosting is implemented this change will be reverted