### PR TITLE
B-03953 Move Settings Page to modal

### DIFF
--- a/src/components/MobileBanner.vue
+++ b/src/components/MobileBanner.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="mobile-banner">
     <MenuIcon @click="showMobileSidebar(true)" />
-    <TopNavMenu :deviceName="deviceName" :white="true" />
+    <TopNavMenu :deviceName="deviceName" :white="true" :openSettingsModal="openSettingsModal" />
     <Sidebar v-if="mobileSidebarVisible" />
     <div v-if="mobileSidebarVisible" class='sidebar-backdrop' @click="showMobileSidebar(false)" />
   </section>
@@ -22,7 +22,8 @@ export default {
   props: {
     deviceName: String,
     showMobileSidebar: Function,
-    mobileSidebarVisible: Boolean
+    mobileSidebarVisible: Boolean,
+    openSettingsModal: Function
   }
 }
 </script>

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -56,12 +56,6 @@ export default {
 }
 
 @media screen and (max-width: 1050px) {
-  .overlay {
-    /* background-color: transparent;
-    pointer-events: none;
-    position: unset;
-    width: auto; */
-  }
   .modal {
     pointer-events: all;
     margin: 210px 10px;

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -30,7 +30,7 @@ export default {
   display: flex;
   top: 0;
   left: 0;
-  z-index: 10;
+  z-index: 200;
   background-color: rgba(49, 60, 89, 0.67);
   width: 100vw;
   height: 100vh;

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -57,14 +57,14 @@ export default {
 
 @media screen and (max-width: 1050px) {
   .overlay {
-    background-color: transparent;
+    /* background-color: transparent;
     pointer-events: none;
     position: unset;
+    width: auto; */
   }
   .modal {
-    box-shadow: 0px 4px 20px #ECEEF1;;
     pointer-events: all;
-    margin: 4px 40px 4px 0;
+    margin: 210px 10px;
     flex-basis: 100%;
     height: fit-content;
   }

--- a/src/components/PrimaryLayout.vue
+++ b/src/components/PrimaryLayout.vue
@@ -2,12 +2,13 @@
   <section class='layout'>
     <Sidebar />
     <section class='main-column'>
-      <MobileBanner :deviceName="deviceName" :showMobileSidebar="showMobileSidebar" :mobileSidebarVisible="mobileSidebarVisible" />
-      <TopNav :breadcrumbs="breadcrumbsOrTitle" :deviceName="deviceName" />
+      <MobileBanner :deviceName="deviceName" :showMobileSidebar="showMobileSidebar" :mobileSidebarVisible="mobileSidebarVisible" :openSettingsModal="openSettingsModal" />
+      <TopNav :breadcrumbs="breadcrumbsOrTitle" :deviceName="deviceName" :openSettingsModal="openSettingsModal" />
       <section class='content'>
         <slot />
       </section>
     </section>
+    <SettingsModal v-if="settingsModalVisible" :handleClose="closeSettingsModal"  />
   </section>
 </template>
 
@@ -16,6 +17,7 @@
 import Sidebar from 'components/Sidebar.vue'
 import TopNav from 'components/TopNav.vue'
 import MobileBanner from 'components/MobileBanner.vue'
+import SettingsModal from 'components/SettingsModal.vue'
 import HposInterface from 'src/interfaces/HposInterface'
 
 export default {
@@ -23,7 +25,8 @@ export default {
   components: {
     Sidebar,
     TopNav,
-    MobileBanner
+    MobileBanner,
+    SettingsModal
   },
   props: {
     title: String,
@@ -32,7 +35,8 @@ export default {
   data () {
     return {
       deviceName: 'Loading...',
-      mobileSidebarVisible: false
+      mobileSidebarVisible: false,
+      settingsModalVisible: true
     }
   },
   async mounted () {
@@ -44,6 +48,12 @@ export default {
   methods: {
     showMobileSidebar (shouldShow = false) {
       this.mobileSidebarVisible = shouldShow
+    },
+    openSettingsModal () {
+      this.settingsModalVisible = true
+    },
+    closeSettingsModal () {
+      this.settingsModalVisible = false
     }
   },
   computed: {

--- a/src/components/PrimaryLayout.vue
+++ b/src/components/PrimaryLayout.vue
@@ -4,11 +4,11 @@
     <section class='main-column'>
       <MobileBanner :deviceName="deviceName" :showMobileSidebar="showMobileSidebar" :mobileSidebarVisible="mobileSidebarVisible" :openSettingsModal="openSettingsModal" />
       <TopNav :breadcrumbs="breadcrumbsOrTitle" :deviceName="deviceName" :openSettingsModal="openSettingsModal" />
+      <SettingsModal v-if="settingsModalVisible" :handleClose="closeSettingsModal"  />
       <section class='content'>
         <slot />
       </section>
     </section>
-    <SettingsModal v-if="settingsModalVisible" :handleClose="closeSettingsModal"  />
   </section>
 </template>
 

--- a/src/components/PrimaryLayout.vue
+++ b/src/components/PrimaryLayout.vue
@@ -36,7 +36,7 @@ export default {
     return {
       deviceName: 'Loading...',
       mobileSidebarVisible: false,
-      settingsModalVisible: true
+      settingsModalVisible: false
     }
   },
   async mounted () {

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,0 +1,230 @@
+<template>
+  <Modal :handleClose="handleClose">
+    <div class='settings-modal'>
+      <h3 class='title'>HoloPort Settings</h3>
+      <h4 class='sub-title'>{{ deviceName }}</h4>
+
+      <section class='settings-rows'>
+        <div class='settings-row'>
+          <div class='row-label'>
+            HPOS Version
+          </div>
+          <div class='row-value'>
+            {{ hposVersion }}
+          </div>
+        </div>
+
+        <div class='settings-row'>
+          <div class='row-label'>
+            <label for='device-name'>Device Name</label>
+          </div>
+          <div v-if='!isEditingDeviceName' class='row-value'>
+            {{ deviceName }}
+            <PencilIcon v-if='!isLoading' @click="editDeviceName" class='pencil' data-testid='edit-button' />
+          </div>
+          <div v-if='isEditingDeviceName' class='row-value' style="position: relative; top: -2px; margin-left: -2px">
+            <input v-model='editedDeviceName' class='device-input' id='device-name'>
+            <FilledCheckIcon @click="saveDeviceName" class='filled-check' data-testid='save-button' />
+            <CircledExIcon @click="cancelEditDeviceName" class='circled-ex' data-testid='cancel-button' />
+          </div>
+        </div>
+
+        <div class='settings-row'>
+          <div class='row-label'>
+            Network
+          </div>
+          <div class='row-value'>
+            {{ networkStatus }}
+          </div>
+        </div>
+
+        <div class='settings-row'>
+          <div class='row-label'>
+            <label for='sshAccess'>Access for HoloPort support (SSH)</label>
+          </div>
+          <div class='row-value'>
+            <input type='checkbox' id='sshAccess' v-model='sshAccess'>
+          </div>
+        </div>
+      </section>
+
+      <Button color='teal' @click="handleClose" class='close-button'>Close</Button>
+    </div>
+  </Modal>
+</template>
+
+<script>
+import Modal from 'components/Modal'
+import Button from 'components/Button'
+import PencilIcon from 'src/components/icons/PencilIcon'
+import FilledCheckIcon from 'src/components/icons/FilledCheckIcon'
+import CircledExIcon from 'src/components/icons/CircledExIcon'
+import HposInterface from 'src/interfaces/HposInterface'
+
+export default {
+  name: 'SettingsModal',
+  components: {
+    Modal,
+    Button,
+    PencilIcon,
+    FilledCheckIcon,
+    CircledExIcon
+  },
+  props: {
+    handleClose: {
+      type: Function,
+      required: true
+    }
+  },
+    data () {
+    return {
+      settings: {},
+      isLoading: true,
+      isEditingDeviceName: false,
+      editedDeviceName: ''
+    }
+  },
+  async mounted () {
+    const settings = await HposInterface.settings()
+    this.settings = settings
+    const sshAccess = await HposInterface.getSshAccess()
+
+    // Need to assign like this to trigger Vue reactivity
+    this.settings = {
+      ...this.settings,
+      sshAccess
+    }
+    this.isLoading = false
+  },
+  methods: {
+    editDeviceName () {
+      // temporarily disabled until hpos bug is fixed
+      // this.editedDeviceName = this.settings.deviceName
+      // this.isEditingDeviceName = true
+    },
+    saveDeviceName () {
+      HposInterface.updateSettings({
+        deviceName: this.editedDeviceName
+      })
+      this.settings.deviceName = this.editedDeviceName
+      this.isEditingDeviceName = false
+    },
+    cancelEditDeviceName () {
+      this.isEditingDeviceName = false
+    },
+  },
+  computed: {
+    hposVersion () {
+      return '70791b'
+    },
+    deviceName () {
+      return this.isLoading ? 'Loading...' : this.settings.deviceName
+    },
+    networkStatus () {
+      return this.isLoading ? 'Loading...' : this.settings.networkStatus
+    },
+    sshAccess: {
+      get () {
+        return this.settings.sshAccess
+      },
+      set (newValue) {
+        if (newValue) {
+          HposInterface.enableSshAccess()
+        } else {
+          HposInterface.disableSshAccess()
+        }
+        this.settings.sshAccess = newValue
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.settings-modal {
+  display: flex;
+  align-items: center;
+  padding: 26px 98px;
+  flex-direction: column;
+  font-style: normal;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 19px;
+  text-align: center;
+  color: #313C59;
+}
+.title {
+  font-weight: 600;
+  font-size: 22px;
+  line-height: 30px;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  color: #313C59;
+  margin: 0 0 12px 0;
+}
+.sub-title {
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 19px;
+  color: #313C59;
+  margin: 0 0 65px 0;
+}
+.settings-rows {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  min-width: 480px;
+  margin-bottom: 132px;
+  font-weight: 600;
+  font-size: 14px;
+  color: #606C8B;
+}
+.settings-row {
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+  width: 100%;
+  line-height: 30px;
+}
+.row-label {
+  flex-basis: 280px;
+  display: flex;
+  align-items: center;
+}
+.row-value {
+  display: flex;
+}
+.factory-reset-link {
+  text-decoration-line: underline;
+  color: #606C8B;
+}
+.question-mark {
+  margin-left: 8px;
+}
+.pencil {
+  margin-left: 5px;
+  margin-top: 3px;
+  cursor: pointer;
+  opacity: 0.2;
+}
+.filled-check {
+  margin-left: 5px;
+  cursor: pointer;
+}
+.circled-ex {
+  margin-left: 5px;
+  cursor: pointer;
+}
+.device-input {
+  border: 0.5px solid #606C8B;
+  color: #313C59;
+}
+.close-button {
+  min-width: 110px;
+  justify-content: center;
+}
+@media screen and (max-width: 1050px) {
+
+}
+</style>

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -225,6 +225,26 @@ export default {
   justify-content: center;
 }
 @media screen and (max-width: 1050px) {
-
+  .settings-modal {
+    padding: 26px 0 28px;
+    margin: 0 -6px;
+  }
+  .title {
+    margin-bottom: 6px;
+  }
+  .sub-title {
+    margin-bottom: 26px
+  }
+  .settings-rows {
+    min-width: 0;
+    width: 100%;
+    margin-bottom: 40px
+  }
+  .row-label {
+    flex-basis: initial;
+  }
+  .row-value {
+    margin-left: auto;
+  }
 }
 </style>

--- a/src/components/StopHostingModal.vue
+++ b/src/components/StopHostingModal.vue
@@ -2,7 +2,7 @@
   <Modal :handleClose="handleClose">
     <div class='stop-hosting-modal' v-if="!confirmed">
       <ExclamationIcon class="exclamation-icon" />
-      <p class='content'>Are you sure you want to stop hosting this hApp?</p>
+      <p class='content'>Are you sure you want to stop hosting {{ happName }}?</p>
       <p class='content'>It will be removed from your HoloPort and will not be available for you to host again for 30 days. All invoices, logs and payments associated with this hApp will remain available to you.</p>
       <div class='buttons'>
         <Button color='teal' @click="confirm">Yes, I want to stop hosting this hApp</Button>
@@ -37,6 +37,10 @@ export default {
   props: {
     handleClose: {
       type: Function,
+      required: true
+    },
+    happName: {
+      type: String,
       required: true
     },
     stopHostingHapp: {

--- a/src/components/TopNav.vue
+++ b/src/components/TopNav.vue
@@ -4,7 +4,7 @@
     <router-link v-if="!!path" class="main-title" :to="path">{{ mainTitle }}</router-link>
     <RightChevronIcon v-if="showSubtitle" class="chevron" />
     <div v-if="showSubtitle" class="sub-title">{{ subTitle }}</div>
-    <TopNavMenu :deviceName="deviceName" />
+    <TopNavMenu :deviceName="deviceName" :openSettingsModal="openSettingsModal" />
     <div class='alpha-flag'>HF = Test Fuel</div>
   </section>
 </template>
@@ -24,7 +24,8 @@ export default {
       type: Array,
       default: [{}, {}]
     },
-    deviceName: String
+    deviceName: String,
+    openSettingsModal: Function
   },
   computed: {
     mainTitle () {

--- a/src/components/TopNavMenu.vue
+++ b/src/components/TopNavMenu.vue
@@ -3,11 +3,9 @@
     <div class="owner" @click="toggleMenu">{{ deviceName }} <DownTriangleIcon class='down-triangle' :white="white" /></div>
     <div class="verification-status">Unverified</div>
     <div v-if="menuOpen" class="menu">
-      <router-link to="/settings" class="settings-link">
-        <div class="menu-item">
-          HoloPort Settings
-        </div>
-      </router-link>
+      <div @click="openSettingsModal" class="menu-item">
+        HoloPort Settings
+      </div>
       <div @click="logout" class="menu-item">Logout</div>
     </div>
   </div>
@@ -24,7 +22,8 @@ export default {
   },
   props: {
     deviceName: String,
-    white: Boolean
+    white: Boolean,
+    openSettingsModal: Function
   },
   data () {
     return {
@@ -104,10 +103,6 @@ export default {
   border-style: solid;
   border-width: 0 6px 6px 6px;
   border-color: transparent transparent white transparent;
-}
-.settings-link {
-  text-decoration: none;
-  color: #606C8B;
 }
 .menu-item {
   padding: 0px 16px;

--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -156,13 +156,11 @@ const HposInterface = {
   },
 
   enableSshAccess: async () => {
-    console.log('enabling ssh access')
     const { enabled } = await hposAdminCall({ method: 'put', path: '/profiles/development/features/ssh' })()
     return enabled
   },
 
   disableSshAccess: async () => {
-    console.log('disabling ssh access')
     const { enabled } = hposAdminCall({ method: 'delete', path: '/profiles/development/features/ssh' })()
     return enabled
   }

--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -156,11 +156,13 @@ const HposInterface = {
   },
 
   enableSshAccess: async () => {
+    console.log('enabling ssh access')
     const { enabled } = await hposAdminCall({ method: 'put', path: '/profiles/development/features/ssh' })()
     return enabled
   },
 
   disableSshAccess: async () => {
+    console.log('disabling ssh access')
     const { enabled } = hposAdminCall({ method: 'delete', path: '/profiles/development/features/ssh' })()
     return enabled
   }

--- a/src/pages/HappDetails.vue
+++ b/src/pages/HappDetails.vue
@@ -66,7 +66,7 @@
         </div>
       </div>
     </div>
-    <StopHostingModal v-if="hostingModalVisible" :handleClose="closeHostingModal" :stopHostingHapp="stopHostingHapp"/>
+    <StopHostingModal v-if="hostingModalVisible" :handleClose="closeHostingModal" :stopHostingHapp="stopHostingHapp" :happName="happ.name" />
   </PrimaryLayout>
 </template>
 
@@ -82,7 +82,6 @@ import PencilIcon from 'components/icons/PencilIcon.vue'
 import AlertCircleIcon from 'components/icons/AlertCircleIcon.vue'
 import { presentHolofuelAmount, presentMicroSeconds, presentBytes } from 'src/utils'
 import HposInterface from 'src/interfaces/HposInterface'
-
 
 export default {
   name: 'HappDetails',

--- a/src/pages/HappDetails.vue
+++ b/src/pages/HappDetails.vue
@@ -126,6 +126,7 @@ export default {
       this.hostingModalVisible = false
     },
     stopHostingHapp () {
+      this.openHostingModal()
       console.log('NOT YET IMPLEMENTED: Stopping hosting happ', this.happ.name)
     },
     presentHolofuelAmount,

--- a/src/pages/HappDetails.vue
+++ b/src/pages/HappDetails.vue
@@ -125,7 +125,6 @@ export default {
       this.hostingModalVisible = false
     },
     stopHostingHapp () {
-      this.openHostingModal()
       console.log('NOT YET IMPLEMENTED: Stopping hosting happ', this.happ.name)
     },
     presentHolofuelAmount,

--- a/src/pages/__tests__/SettingsModal.test.js
+++ b/src/pages/__tests__/SettingsModal.test.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { render, waitFor, fireEvent } from '@testing-library/vue'
 import wait from 'waait'
 import { HPOS_API_URL } from 'src/interfaces/HposInterface'
-import Settings from '../Settings.vue'
+import Earnings from '../Earnings.vue'
 import { routes } from 'src/router'
 
 jest.mock('axios')
@@ -35,6 +35,21 @@ const defaultSshAccessResult = {
   data: { enabled: true }
 }
 
+const renderSettingsModal = async () => {
+  const queries = render(Earnings, {routes})
+  const { getAllByText } = queries
+  await wait(0)
+
+  const menu = getAllByText("Lana Wilson's HP")[0]
+  fireEvent.click(menu)
+  await wait(0)
+
+  const settingsLink = getAllByText("HoloPort Settings")[0]
+  fireEvent.click(settingsLink)
+
+  return queries
+}
+
 describe('Settings page', () => {
   beforeEach(() => {
     axios.get.mockClear()
@@ -45,48 +60,49 @@ describe('Settings page', () => {
         return Promise.resolve(defaultSettingsResult)
       } else if (path.endsWith('/api/v1/profiles/development/features/ssh')) {
         return Promise.resolve(defaultSshAccessResult)
+      } else {
+        throw new Error(`Unhandled axios path: ${path}`)
       }
     })
   })
 
   it('renders the deviceName and network type', async () => {
-    const { getAllByText } = render(Settings, {routes})
-    await wait(0)
+    const { getAllByText } = await renderSettingsModal()
 
     await waitFor(() => getAllByText(defaultSettings.deviceName))
     await waitFor(() => getAllByText(defaultSettings.holoportos.network))
   })
 
   // this is skipped until the hpos config update is fixed. See also Settings.vue
-  it.skip('handles devicename interactions correctly', async () => {    
+  it.skip('handles devicename interactions correctly', async () => {
     axios.put.mockImplementationOnce(() => Promise.resolve(defaultSettingsResult))
 
     const newDeviceName = "Sean's HP"
 
-    const { getByLabelText, getByTestId } = render(Settings, {routes})
-  
+    const { getByLabelText, getByTestId } = await renderSettingsModal()
+
     await waitFor(() => getByTestId('edit-button'))
 
     const editButton = getByTestId('edit-button')
     fireEvent.click(editButton)
 
     await wait(0)
-    
+
     const input = getByLabelText('Device Name')
     fireEvent.update(input, 'the wrong device name')
 
     const cancelButton = getByTestId('cancel-button')
     fireEvent.click(cancelButton)
 
-    await wait(0)  
+    await wait(0)
 
     // check that cancel doesn't save the device name
-    expect(axios.put.mock.calls.length).toEqual(0)    
+    expect(axios.put.mock.calls.length).toEqual(0)
 
     fireEvent.click(editButton)
 
     await wait(0)
-    
+
     fireEvent.update(input, newDeviceName)
 
     const saveButton = getByTestId('save-button')
@@ -95,7 +111,7 @@ describe('Settings page', () => {
     await wait(0)
 
     // check that save does save the device name
-    expect(axios.put.mock.calls[0][1].deviceName).toEqual(newDeviceName)    
+    expect(axios.put.mock.calls[0][1].deviceName).toEqual(newDeviceName)
   })
 
   it('saves changes to ssh access', async () => {
@@ -105,7 +121,7 @@ describe('Settings page', () => {
     axios.delete
       .mockImplementationOnce(() => Promise.resolve({ data: { enabled: false } }))
 
-    const { getByLabelText, getByTestId } = render(Settings, {routes})
+    const { getByLabelText, getByTestId } = await renderSettingsModal()
 
     // wait til settings have loaded
     await waitFor(() => getByTestId('edit-button'))

--- a/src/pages/__tests__/SettingsModal.test.js
+++ b/src/pages/__tests__/SettingsModal.test.js
@@ -36,6 +36,8 @@ const defaultSshAccessResult = {
 }
 
 const renderSettingsModal = async () => {
+  // using the Earnings page for the base as it doesn't have any extra api calls that need mocking
+  // As that changes, feel free to use a different page, or even add an empty page for this purpose.
   const queries = render(Earnings, {routes})
   const { getAllByText } = queries
   await wait(0)

--- a/src/router.js
+++ b/src/router.js
@@ -91,9 +91,6 @@ export const routerFactory = () => {
     if (to.matched.some(record => record.meta.requiresAuth)) {
       // page only visible when logged in
 
-      // TODO remove before merging
-      return next()
-
       // isAuthed is true if the last keypair we generated was good. It persists across sessions.
       // checkHpAdminKeypair checks if we have a keypair in *this* session. If we don't, then we remove isAuthed
       // another way to handle this would be to store isAuthed in app state not local storage. Then we wouldn't need this line.


### PR DESCRIPTION
This moves the settings page to a modal. It sort of reflects these designs:

https://www.figma.com/file/aByn6m2OoiMiYqpflX0taw/Release-.3?node-id=409%3A249

But after conversation with @celestialhanley, the MOBILE version of the modal design has been updated to a hybrid of the two mobile modal designs in the Figma.

Specifically, it has the darkened overlay, but moves the modal down so you can see the page title of the page you're on top of.