### PR TITLE
Implement proper signing and allow using HoloPort as backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,34 @@
 
 ## Project setup
 ```
-npm install
+yarn install
 ```
 
 Copy the .env.example file to .env, and modify values to taste.
 
+### Start UI server using real HoloPort as backend
+```
+VUE_APP_HOLOPORT_URL=your_holoport_url_here
+```
+
+e.g.
+
+```
+VUE_APP_HOLOPORT_URL=https://00000000000000000000000000000000000000000000000000.holohost.dev yarn serve
+```
+
+Using this command, all requests to `localhost:8080/api/` and `localhost:8080/holochain-api/` are forwarded to the holoport. This is really helpful for development/testing.
+
 ### Start UI server for development
 ```
-npm run serve
+yarn run serve
 ```
 
 You will mostly want to run this along with the next command
 
 ### Start mock HPOS API server for development
 ```
-npm run start-mock-hpos-api
+yarn run start-mock-hpos-api
 ```
 
 The login email and password for this server are in the package.json script
@@ -26,24 +39,25 @@ and
 
 ### Start both UI server and mock API server with one command
 ```
-npm run start-ui-and-mock
+yarn run start-ui-and-mock
 ```
+
 
 ### Run tests
 ```
-npm run test
+yarn run test
 ```
 
 Note: you must have a .env file with `VUE_APP_HPOS_PORT` for tests to pass.
 
 ### Compiles and minifies for production
 ```
-npm run  build
+yarn run build
 ```
 
 ### Lints and fixes files
 ```
-npm run lint
+yarn run lint
 ```
 
 ### Customize configuration

--- a/mock-hpos-api/authUtils.js
+++ b/mock-hpos-api/authUtils.js
@@ -5,9 +5,13 @@ const sha512 = require('js-sha512')
 
 const verifySignedRequest = (givenSignature, method, pathIncludingQuery, body, keypair) => {
   // BUG: real server (hp-admin-crypto) does not properly check the body when
-  //      verifying signature. pass empty string so that it validates
+  //      verifying signature [1]. pass empty string so that it validates
   //      successfully
+  //
+  // [1]: https://github.com/Holo-Host/hp-admin-crypto/issues/25
+  //
   // correct code:
+  //
   // let body_to_sign = stringify(body)
   // if (body_to_sign === '{}') {
   //   body_to_sign = ''

--- a/mock-hpos-api/index.js
+++ b/mock-hpos-api/index.js
@@ -24,7 +24,7 @@ class MockHposApi {
     this.shouldCheckAuth = !!authEmail && !!authPassword
     this.authEmail = authEmail
     this.authPassword = authPassword
-    
+
     this.initializeResponses()
   }
 
@@ -86,8 +86,8 @@ class MockHposApi {
     if (!this.responseQueues[responseKey]) {
       this.responseQueues[responseKey] = []
     }
-  
-    this.responseQueues[responseKey].push(response)  
+
+    this.responseQueues[responseKey].push(response)
   }
 
   getSavedResponse (method, type, data) {
@@ -111,7 +111,7 @@ class MockHposApi {
 
   initializeResponses () {
     this.responseQueues = {}
-    // sets the `any` response which is called as a fallback when no other response has been specified. 
+    // sets the `any` response which is called as a fallback when no other response has been specified.
     // In this case, defaultResponse is a mock of normal behavior of the hpos apis
     this.anyResponse = defaultResponse
   }
@@ -119,7 +119,7 @@ class MockHposApi {
   handleRequest (req, res) {
     const { method, path, body } = req
 
-    let responseOrResponseFunc 
+    let responseOrResponseFunc
     try {
       responseOrResponseFunc = this.getSavedResponse(method, path, body)
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "serve": "VUE_APP_UI_VERSION=$npm_package_version vue-cli-service serve",
-    "start-ui-and-mock": "npm run start-mock-hpos-api & npm run serve",
+    "start-ui-and-mock": "npm run start-mock-hpos-api-with-auth & npm run serve",
     "build": "VUE_APP_UI_VERSION=$npm_package_version VUE_APP_USE_REAL_PUB_KEY=true vue-cli-service build",
     "build:dev": "VUE_APP_UI_VERSION=$npm_package_version VUE_APP_USE_REAL_PUB_KEY=true vue-cli-service build --mode development",
     "lint": "vue-cli-service lint",
@@ -14,7 +14,7 @@
     "start-mock-hpos-api-with-auth": "node mock-hpos-api/runMockHposApi.js --email test@test.com --password asasas"
   },
   "dependencies": {
-    "@holo-host/hp-admin-keypair": "^0.1.3",
+    "@holo-host/hp-admin-keypair": "^0.2.3",
     "axios": "^0.21.0",
     "body-parser": "^1.19.0",
     "core-js": "^3.6.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start-mock-hpos-api-with-auth": "node mock-hpos-api/runMockHposApi.js --email test@test.com --password asasas"
   },
   "dependencies": {
-    "@holo-host/hp-admin-keypair": "^0.2.3",
+    "@holo-host/hp-admin-keypair": "^0.2.6",
     "axios": "^0.21.0",
     "body-parser": "^1.19.0",
     "core-js": "^3.6.5",

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -98,7 +98,8 @@ export default {
   },
   methods: {
     editDeviceName () {
-      // Disabled until we get auth working
+      // BUG: hpos-admin-api does not properly save config due to permissions issue.
+      //      Disable editing device name until bug is fixed
       // this.editedDeviceName = this.settings.deviceName
       // this.isEditingDeviceName = true
     },
@@ -205,7 +206,9 @@ export default {
 .pencil {
   margin-left: 5px;
   margin-top: 3px;
-  /* cursor: pointer; */
+
+  /* Disable editing device name until bug is fixed
+  cursor: pointer; */
   opacity: 0.2;
 }
 .filled-check {

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -98,8 +98,13 @@ export default {
   },
   methods: {
     editDeviceName () {
-      // BUG: hpos-admin-api does not properly save config due to permissions issue.
+      // BUG: hpos-admin-api does not properly save config due to permissions issue. [1]
       //      Disable editing device name until bug is fixed
+      //
+      // [1]: https://github.com/Holo-Host/holo-nixpkgs/issues/1068
+      //
+      // correct code:
+      //
       // this.editedDeviceName = this.settings.deviceName
       // this.isEditingDeviceName = true
     },

--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -1,8 +1,7 @@
 require('dotenv').config() // this is necessary for testing. Otherwise the process.env does not get set up befoe constants are defined
 import axios from 'axios'
-import { omitBy, isUndefined } from 'lodash/fp'
 import mergeMockHappData from 'src/mergeMockHappData'
-import { signPayload, hashString } from 'src/utils/keyManagement'
+import { signRequest, hashString } from 'src/utils/keyManagement'
 import stringify from 'fast-json-stable-stringify'
 
 const axiosConfig = {
@@ -19,43 +18,31 @@ export const HPOS_API_URL = HPOS_PORT
   ? `http://localhost:${HPOS_PORT}`
   : (window.location.protocol + '//' + window.location.hostname)
 
-export function hposCall ({ pathPrefix = '/api/v1', method = 'get', path, headers: userHeaders = {} }) {
+function hposCall ({ pathPrefix, method = 'get', path, headers: userHeaders = {} }) {
   return async params => {
-    const fullPath = HPOS_API_URL + pathPrefix + path
+    const fullUrl = HPOS_API_URL + pathPrefix + path
 
-    const urlObj = new URL(fullPath)
-
-    let bodyHash
-    let signature
-
-    if (params) {
-      bodyHash = await hashString(stringify(params))
-      signature = await signPayload(method, `${urlObj.pathname}?${new URLSearchParams(params).toString()}`, bodyHash)
-    } else {
-      signature = await signPayload(method, urlObj.pathname, bodyHash)
-    }
-
-    const headers = omitBy(isUndefined, {
+    const signature = await signRequest(method, fullUrl, params)
+    const headers = {
       ...axiosConfig.headers,
       ...userHeaders,
-      'X-Body-Hash': bodyHash,
       'X-Hpos-Admin-Signature': signature
-    })
+    }
 
     let data
 
     switch (method) {
       case 'get':
-        ({ data } = await axios.get(fullPath, { params, headers }))
+        ({ data } = await axios.get(fullUrl, { params, headers }))
         return data
       case 'post':
-        ({ data } = await axios.post(fullPath, params, { headers }))
+        ({ data } = await axios.post(fullUrl, params, { headers }))
         return data
       case 'put':
-        ({ data } = await axios.put(fullPath, params, { headers }))
+        ({ data } = await axios.put(fullUrl, params, { headers }))
         return data
       case 'delete':
-        ({ data } = await axios.delete(fullPath, { params, headers }))
+        ({ data } = await axios.delete(fullUrl, { params, headers }))
         return data
       default:
         throw new Error(`No case in hposCall for ${method} method`)
@@ -125,7 +112,7 @@ const HposInterface = {
     try {
       await HposInterface.settings()
     } catch (error) {
-      console.log('checkAuth failed')
+      console.log('checkAuth failed', error)
       return false
     }
 

--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -26,12 +26,14 @@ export function hposCall ({ pathPrefix = '/api/v1', method = 'get', path, header
     const urlObj = new URL(fullPath)
 
     let bodyHash
+    let signature
 
     if (params) {
       bodyHash = await hashString(stringify(params))
+      signature = await signPayload(method, `${urlObj.pathname}?${new URLSearchParams(params).toString()}`, bodyHash)
+    } else {
+      signature = await signPayload(method, urlObj.pathname, bodyHash)
     }
-
-    const signature = await signPayload(method, urlObj.pathname, bodyHash)
 
     const headers = omitBy(isUndefined, {
       ...axiosConfig.headers,

--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -16,7 +16,7 @@ const HPOS_PORT = process.env.NODE_ENV === 'test' ? Number(process.env.VUE_APP_H
 
 export const HPOS_API_URL = HPOS_PORT
   ? `http://localhost:${HPOS_PORT}`
-  : (window.location.protocol + '//' + window.location.hostname)
+  : (window.location.protocol + '//' + window.location.host)
 
 function hposCall ({ pathPrefix, method = 'get', path, headers: userHeaders = {} }) {
   return async params => {

--- a/src/pages/EarningsInvoices.vue
+++ b/src/pages/EarningsInvoices.vue
@@ -248,6 +248,9 @@ export default {
     invoiceCount () {
       return this.filteredSortedInvoices.length
     },
+    SORT_AMOUNT () {
+      return SORT_AMOUNT
+    },
   },
   methods: {
     presentPublisherHash,

--- a/src/pages/__tests__/HostedHapps.test.js
+++ b/src/pages/__tests__/HostedHapps.test.js
@@ -30,7 +30,7 @@ it('calls the hosted_happs endpoint', async () => {
         data: {
           admin: {}
         }
-      }      
+      }
     }
 
     throw new Error (`axios mock doesn't recognise this path: ${path}`)
@@ -40,5 +40,5 @@ it('calls the hosted_happs endpoint', async () => {
 
   await wait(0)
 
-  expect(axios.get.mock.calls[1][0]).toEqual(`${HPOS_API_URL}/holochain-api/v1/hosted_happs`)
+  expect(axios.get.mock.calls[0][0]).toEqual(`${HPOS_API_URL}/holochain-api/v1/hosted_happs`)
 })

--- a/src/utils/keyManagement.js
+++ b/src/utils/keyManagement.js
@@ -64,8 +64,13 @@ export const signRequest = async (method, url, params) => {
       case 'post':
       case 'put':
         // BUG: real server (hp-admin-crypto) does not properly check the body when
-        //      verifying signature. pass empty string so that it validates
+        //      verifying signature [1]. pass empty string so that it validates
         //      successfully
+        //
+        // [1]: https://github.com/Holo-Host/hp-admin-crypto/issues/25
+        //
+        // correct code:
+        //
         // body = stringify(params)
         break
       default:

--- a/src/utils/keyManagement.js
+++ b/src/utils/keyManagement.js
@@ -4,9 +4,13 @@ import stringify from 'fast-json-stable-stringify'
 
 // Parse window.location to retrieve holoPort's HC public key (3rd level subdomain in URL)
 const getHcPubkey = () => {
-  return ((process.env.VUE_APP_USE_REAL_PUB_KEY !== 'true')
-    ? '5m5srup6m3b2iilrsqmxu6ydp8p8cr0rdbh4wamupk3s4sxqr5'
-    : window.location.hostname.split('.')[0])
+  if (process.env.VUE_APP_USE_REAL_PUB_KEY === 'true') {
+    return window.location.hostname.split('.')[0]
+  } else if (process.env.VUE_APP_HOLOPORT_URL) {
+    return (new URL(process.env.VUE_APP_HOLOPORT_URL)).hostname.split('.')[0]
+  } else {
+    return '5m5srup6m3b2iilrsqmxu6ydp8p8cr0rdbh4wamupk3s4sxqr5'
+  }
 }
 
 // This import has to be async because of the way that dumb webpack interacts with wasm

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,7 @@
 const path = require('path')
 
+const holoportUrl = process.env.VUE_APP_HOLOPORT_URL
+
 module.exports = {
   lintOnSave: false,
   configureWebpack: {
@@ -7,8 +9,18 @@ module.exports = {
       alias: {
         src: path.resolve(__dirname, 'src'),
         components: path.resolve(__dirname, 'src/components'),
-        pages: path.resolve(__dirname, 'src/pages'),        
+        pages: path.resolve(__dirname, 'src/pages'),
       }
     }
-  }
+  },
+  devServer: holoportUrl && {
+    proxy: {
+      '/api/*': {
+        target: holoportUrl
+      },
+      '/holochain-api/*': {
+        target: holoportUrl
+      }
+    },
+  },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,10 +913,10 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
-"@holo-host/hp-admin-keypair@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@holo-host/hp-admin-keypair/-/hp-admin-keypair-0.2.2.tgz#db3865a9ba19d33e1ca6a5961851aab2d7542a7b"
-  integrity sha512-CxQcbfTfIMRp68nKWXDYP+f1dFuujnpVoNBcp+XIB4H4BGDByv1u8DeLrpTofbiWr7rlsxEegLFi7g9sdyAmBg==
+"@holo-host/hp-admin-keypair@^0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@holo-host/hp-admin-keypair/-/hp-admin-keypair-0.2.6.tgz#c9c421550fd4295ddf8e55481d4b65b4db184134"
+  integrity sha512-uPftqjiRS8DNCCKWtiwhWS744KHS+Q8Jk3mjRF0UA8uBsX+bzHrwzzx/boQeMQeBSR1rI2sphhXcAhh104qxhA==
 
 "@intervolga/optimize-cssnano-plugin@^1.0.5":
   version "1.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,10 +913,10 @@
   dependencies:
     "@hapi/hoek" "^8.3.0"
 
-"@holo-host/hp-admin-keypair@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@holo-host/hp-admin-keypair/-/hp-admin-keypair-0.1.3.tgz#f566a1729aeea542f39513de545490ff7eef3eea"
-  integrity sha512-ba/fcn+uKX/3ml4bOk66z1i8LFmBrso2R+mst4dJ/p9FzcsBcFvwOkmwYyfuhsK+texckiXFKs6DEqufClKBWA==
+"@holo-host/hp-admin-keypair@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@holo-host/hp-admin-keypair/-/hp-admin-keypair-0.2.2.tgz#db3865a9ba19d33e1ca6a5961851aab2d7542a7b"
+  integrity sha512-CxQcbfTfIMRp68nKWXDYP+f1dFuujnpVoNBcp+XIB4H4BGDByv1u8DeLrpTofbiWr7rlsxEegLFi7g9sdyAmBg==
 
 "@intervolga/optimize-cssnano-plugin@^1.0.5":
   version "1.0.6"


### PR DESCRIPTION
Includes #39

Changes:
- Updates logic for signing API requests
- Adds feature where devs can specify `VUE_APP_HOLOPORT_URL=` to use a HoloPort as the backend during local development

I have verified that the signing implemented works with a HoloPort on holo-nixpkgs develop. I don't get any 401 errors.
I have also verified that unit tests pass and that the local development mock doesn't return any 401 errors either.

Specific commits tested:
- https://github.com/Holo-Host/holo-nixpkgs/commit/ff0ddee477161769adab5ab551e249c78a6d35d7
  - which uses https://github.com/Holo-Host/hp-admin-crypto/commit/6aa480b51357fd0946b11c5868d98275b466e4b1

I did encounter a bug with hpos-admin-api that prevents editing device names. I will provide a full writeup in another channel