### PR TITLE
rename /dashboard to /usage

### DIFF
--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -41,7 +41,7 @@ const happs = [{
 const usage = {
   totalSourceChains: 387,
   currentTotalStorage: 590348543805,
-  usage: {
+  totalUsage: {
     cpu: 39084998,
     bandwidth: 5094853480509
   }

--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -38,7 +38,7 @@ const happs = [{
   enabled: false
 }]
 
-const dashboard = {
+const usage = {
   totalSourceChains: 387,
   currentTotalStorage: 590348543805,
   usage: {
@@ -61,7 +61,7 @@ const data = {
       enabled: true
     },
     '/holochain-api/v1/hosted_happs': happs,
-    '/holochain-api/v1/dashboard': dashboard
+    '/holochain-api/v1/usage': usage
   },
   put: {
     '/api/v1/config': args => args,

--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -173,7 +173,7 @@ const HposInterface = {
       })
     } catch (err) {
       // This will be executed if response.status === 401
-      console.log('User authentication failed', error)
+      console.log('User authentication failed', err)
       return false
     }
 

--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -95,18 +95,17 @@ const presentHposSettings = (hposSettings) => {
 }
 
 const HposInterface = {
-  dashboard: async () => {
+  usage: async () => {
     try {
-      const dashboardData = await hposHolochainCall({
+      const usageData = await hposHolochainCall({
         method: 'get',
-        path: '/dashboard' ,
+        path: '/usage' ,
         params: {
           duration_unit: 'DAY',
           amount: 1
         }
       })
-      dashboardData.currentTotalStorage = '--' // currently hiding this value from the UI as it's mock data coming from the api
-      return dashboardData
+      return usageData
     } catch (err) {
       return {}
     }

--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -172,7 +172,7 @@ const HposInterface = {
       })
     } catch (error) {
       // This will be executed if error.response.status === 401
-      console.log('User authentication failed')
+      console.log('User authentication failed ', error)
       return false
     }
 

--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -107,6 +107,7 @@ const HposInterface = {
       })
       return usageData
     } catch (err) {
+      console.error("usage encountered an error: ", err)
       return {}
     }
   },
@@ -170,9 +171,9 @@ const HposInterface = {
         method: 'get', path: '/config', headers: signatureHeader,
         pathPrefix: '/api/v1'
       })
-    } catch (error) {
-      // This will be executed if error.response.status === 401
-      console.log('User authentication failed ', error)
+    } catch (err) {
+      // This will be executed if response.status === 401
+      console.log('User authentication failed', error)
       return false
     }
 

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -7,7 +7,7 @@
           <div class="inner-column">
             <h3 class="inner-title">hApps</h3>
             <div class="info-row">
-              <span class="bold" data-testid='happ-no'>{{ totalHostedHapps }}&nbsp;</span> Total hApps hosted
+              <span class="bold" data-testid='happ-no'>{{ dashboard.totalHostedHapps ||  "--" }}&nbsp;</span> Total hApps hosted
             </div>
             <div class="info-row">
               <span class="bold" data-testid='sc-no'>{{ dashboard.totalSourceChains }}&nbsp;</span> Total source chains hosted
@@ -20,7 +20,7 @@
             <h3 class="inner-title">Daily Snapshot</h3>
             <div class="info-row">
               <span class="daily-label">CPU</span>
-              <span class="bold">{{ presentMicroSeconds(dashboard.usage.cpu) }}</span>
+              <span class="bold">{{ presentMicroSeconds(dashboard.totalUsage.cpu) }}</span>
             </div>
             <div class="info-row">
               <span class="daily-label">Storage</span>
@@ -28,7 +28,7 @@
             </div>
             <div class="info-row">
               <span class="daily-label">Bandwidth</span>
-              <span class="bold">{{ presentBytes(dashboard.usage.bandwidth) }}</span>
+              <span class="bold">{{ presentBytes(dashboard.totalUsage.bandwidth) }}</span>
             </div>
           </div>
         </div>
@@ -157,16 +157,14 @@ export default {
   data () {
     return {
       dashboard: {
-        usage: {}
+        totalUsage: {},
       },
-      totalHostedHapps: '--',
       topHostedHapps,
       recentPayments
     }
   },
   created: async function () {
     this.dashboard = await HposInterface.usage()
-    this.totalHostedHapps = (await HposInterface.hostedHapps()).length
   },
   methods: {
     presentMicroSeconds,

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -165,7 +165,7 @@ export default {
     }
   },
   created: async function () {
-    this.dashboard = await HposInterface.dashboard()
+    this.dashboard = await HposInterface.usage()
     this.totalHostedHapps = (await HposInterface.hostedHapps()).length
   },
   methods: {

--- a/src/pages/__tests__/Dashboard.test.js
+++ b/src/pages/__tests__/Dashboard.test.js
@@ -24,7 +24,7 @@ describe('dashboard page', () => {
       data: {
         totalSourceChains: 387,
         currentTotalStorage: 590348543805,
-        usage: {
+        totalUsage: {
           cpu: 39084998,
           bandwidth: 5094853480509
         }

--- a/src/pages/__tests__/Dashboard.test.js
+++ b/src/pages/__tests__/Dashboard.test.js
@@ -52,7 +52,7 @@ describe('dashboard page', () => {
         }
       }
 
-      if (path.endsWith('dashboard')) {
+      if (path.endsWith('usage')) {
         return usageResult
       }
 

--- a/src/pages/__tests__/Dashboard.test.js
+++ b/src/pages/__tests__/Dashboard.test.js
@@ -20,7 +20,7 @@ describe('dashboard page', () => {
       data: [{ enabled: true }, { enabled: true }, { enabled: true }] // this page just cares about length
     }
 
-    const dashboardResult = {
+    const usageResult = {
       data: {
         totalSourceChains: 387,
         currentTotalStorage: 590348543805,
@@ -53,7 +53,7 @@ describe('dashboard page', () => {
       }
 
       if (path.endsWith('dashboard')) {
-        return dashboardResult
+        return usageResult
       }
 
       throw new Error(`axios mock doesn't recognise this path: ${path}`)
@@ -66,6 +66,6 @@ describe('dashboard page', () => {
     await wait(0)
 
     expect(getByTestId('happ-no').textContent === hostedHappsResult.data.length)
-    expect(getByTestId('sc-no').textContent === dashboardResult.data.totalSourceChains)
+    expect(getByTestId('sc-no').textContent === usageResult.data.totalSourceChains)
   })
 })


### PR DESCRIPTION
### Updates:
  - renames `/dashboard` to `/usage` to match hpos-hc-api updates
  - updates `/usage` return values
  - updates mock values in tests
  
  > NB: This pairs with [holo-nixpkgs pr #1325](https://github.com/Holo-Host/holo-nixpkgs/pull/1325) - which includes the updated holochain-api updates, hf in self-hosted context - and is required for passing regression tests. 