### PR TITLE
feature(happs-page): show different message when no happs after filtering

### DIFF
--- a/src/components/hApps/HappCard.vue
+++ b/src/components/hApps/HappCard.vue
@@ -4,7 +4,7 @@
       v-if="isEmpty"
       class="happ-card__content happ-card__content--empty"
     >
-      {{ $t('hosted_happs.no_happs') }}
+      {{ $t(emptyCardLabel) }}
     </div>
 
     <div
@@ -61,6 +61,11 @@ const props = defineProps({
   isEmpty: {
     type: Boolean,
     default: false
+  },
+
+  emptyCardLabel: {
+    type: String,
+    default: 'hosted_happs.no_happs'
   }
 })
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -48,6 +48,7 @@ const translations = {
   hosted_happs: {
     hosted_for: 'Hosted for',
     no_happs: 'You’re not hosting any hApps',
+    no_filtered_happs: 'No hApps match your search',
     title: 'Top Hosted hApps'
   },
   invoices: {

--- a/src/pages/HAppsPage.vue
+++ b/src/pages/HAppsPage.vue
@@ -40,6 +40,7 @@
       >
         <HappCard
           is-empty
+          :empty-card-label="filterValue ? 'hosted_happs.no_filtered_happs' : 'hosted_happs.no_happs'"
           class="happs__happ-list-item"
         />
       </div>


### PR DESCRIPTION
This PR adds different message to an empty list item when user filtered the list with no matching results.

<img width="1481" alt="Screenshot 2022-10-13 at 12 03 49" src="https://user-images.githubusercontent.com/17565389/195567785-9c7bafad-c824-44b0-ac48-9d90c0f1d7a7.png">
