### PR TITLE
fix(earnings-page): broken layout due to style changes

### DIFF
--- a/src/components/earnings/WeeklyEarningsData.vue
+++ b/src/components/earnings/WeeklyEarningsData.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="weekly-earnings-data">
     <CardHeader
-      :label="$t('earnings.weekly_earnings')"
+      :label="$t('earnings.last_7_days')"
       :amount="weeklyEarnings"
     >
       <BaseButton
@@ -17,9 +17,9 @@
 </template>
 
 <script setup>
-import BaseButton from '@uicommon/components/BaseButton'
-import CardHeader from 'components/earnings/CardHeader'
-import TmpGraphIcon from 'components/icons/TmpGraphIcon'
+import BaseButton from '@uicommon/components/BaseButton.vue'
+import CardHeader from './CardHeader.vue'
+import TmpGraphIcon from '@/components/icons/TmpGraphIcon.vue'
 import { useGoToHoloFuel } from '@/composables/useGoToHoloFuel'
 
 defineProps({

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -30,7 +30,7 @@ const translations = {
     redemption_history: 'Redemption History',
     title: 'Earnings',
     transfer_holofuel: 'Transfer HoloFuel',
-    unpaid_and_late: 'Unpaid & Late',
+    unpaid_and_late: 'Unpaid & Late Invoices',
     unpaid_invoices: 'Unpaid Invoices',
     weekly_earnings: 'Weekly Earnings'
   },

--- a/src/pages/EarningsPage.vue
+++ b/src/pages/EarningsPage.vue
@@ -3,29 +3,31 @@
     :title="$t('$.earnings')"
     data-testid="earnings-page"
   >
-    <WeeklyEarningsCard
-      :data="weeklyEarnings"
-      :is-loading="isLoading"
-      :is-error="isError"
-      @try-again-clicked="getEarnings"
-    />
+    <div>
+      <WeeklyEarningsCard
+        :data="weeklyEarnings"
+        :is-loading="isLoading"
+        :is-error="isError"
+        @try-again-clicked="getEarnings"
+      />
 
-    <RedeemableHoloFuelCard
-      :data="redeemableHoloFuel"
-      :is-loading="false"
-      :is-error="false"
-      class="redeemable-holofuel-card"
-      @try-again-clicked="getEarnings"
-    />
+      <RedeemableHoloFuelCard
+        :data="redeemableHoloFuel"
+        :is-loading="false"
+        :is-error="false"
+        class="redeemable-holofuel-card"
+        @try-again-clicked="getEarnings"
+      />
+    </div>
   </PrimaryLayout>
 </template>
 
 <script setup>
 import { formatCurrency } from '@uicommon/utils/numbers'
-import RedeemableHoloFuelCard from 'components/earnings/RedeemableHoloFuelCard'
-import WeeklyEarningsCard from 'components/earnings/WeeklyEarningsCard'
-import PrimaryLayout from 'components/PrimaryLayout.vue'
 import { computed, onMounted, ref } from 'vue'
+import RedeemableHoloFuelCard from '@/components/earnings/RedeemableHoloFuelCard.vue'
+import WeeklyEarningsCard from '@/components/earnings/WeeklyEarningsCard.vue'
+import PrimaryLayout from '@/components/PrimaryLayout.vue'
 import { useDashboardStore } from '@/store/dashboard'
 
 const dashboardStore = useDashboardStore()


### PR DESCRIPTION
This is a fix to recent style change that broke the earnings page layout

Before:
<img width="1501" alt="Screenshot 2022-10-20 at 12 48 35" src="https://user-images.githubusercontent.com/17565389/196928861-e0fac6d5-5d44-4db8-9302-0ce0d245ab09.png">


After:
<img width="1496" alt="Screenshot 2022-10-20 at 12 47 52" src="https://user-images.githubusercontent.com/17565389/196928728-6d1e7e83-cef3-4a54-aa36-940612549fb8.png">
