### PR TITLE
Add hosting preferences endpoints

### DIFF
--- a/src/components/TimeDropdownSelect.vue
+++ b/src/components/TimeDropdownSelect.vue
@@ -10,7 +10,7 @@
       :key="option"
       :value="option"
     >
-      {{ option }} {{ $t('$.days') }}
+      {{ option }} {{ option !== 'N/A' ? $t('$.days') : '' }}
     </option>
   </select>
 </template>
@@ -23,7 +23,7 @@ defineProps({
   },
 
   value: {
-    type: Number,
+    type: [Number, String],
     required: true
   },
 

--- a/src/components/dashboard/RecentPaymentsCard.vue
+++ b/src/components/dashboard/RecentPaymentsCard.vue
@@ -18,7 +18,7 @@
         class="payment-row"
       >
         <div class="payment-amount">
-          {{ props.data && Number(payment.amount) ? formatCurrency(payment.amount) : 0 }} HF
+          {{ payment.amount && Number(payment.amount) ? formatCurrency(Number(payment.amount)) : 0 }} HF
         </div>
         <div class="payment-details">
           <div>

--- a/src/components/settings/hostingPreferences/EditablePriceRow.vue
+++ b/src/components/settings/hostingPreferences/EditablePriceRow.vue
@@ -54,7 +54,7 @@ const props = defineProps({
   },
 
   value: {
-    type: Number,
+    type: [Number, String],
     required: true
   },
 

--- a/src/components/settings/hostingPreferences/InvoicesDueRow.vue
+++ b/src/components/settings/hostingPreferences/InvoicesDueRow.vue
@@ -9,7 +9,7 @@
     <TimeDropdownSelect
       is-disabled
       :value="data.due.period"
-      :options="[7,30]"
+      :options="['N/A', 7, 30]"
       @update:selected-value="onDueChange"
     />
 

--- a/src/components/settings/hostingPreferences/InvoicesFrequencyRow.vue
+++ b/src/components/settings/hostingPreferences/InvoicesFrequencyRow.vue
@@ -9,7 +9,7 @@
     <TimeDropdownSelect
       is-disabled
       :value="data.frequency.period"
-      :options="[7,30]"
+      :options="['N/A', 7, 30]"
       @update:selected-value="onFrequencyPeriodChange"
     />
 

--- a/src/components/settings/hostingPreferences/InvoicesSection.vue
+++ b/src/components/settings/hostingPreferences/InvoicesSection.vue
@@ -18,13 +18,13 @@
       <div class="invoices-section__notes">
         <div>
           <span>{{ $t('hosting_preferences.invoices.note_one.part_one') }}</span>
-          <span class="invoices-section__notes-value">{{ 2 * data.due.period }} {{ $t('$.days') }}</span>
+          <span class="invoices-section__notes-value">{{ 2 * data.due.period || 'N/A' }} {{ $t('$.days') }}</span>
           <span>{{ $t('hosting_preferences.invoices.note_one.part_two') }}</span>
         </div>
 
         <div class="invoices-section__note-two">
           <span>{{ $t('hosting_preferences.invoices.note_two.part_one') }}</span>
-          <span class="invoices-section__notes-value">{{ 4 * data.due.period }} {{ $t('$.days') }}</span>
+          <span class="invoices-section__notes-value">{{ 4 * data.due.period || 'N/A' }} {{ $t('$.days') }}</span>
           <span>{{ $t('hosting_preferences.invoices.note_two.part_two') }}</span>
         </div>
       </div>
@@ -65,6 +65,7 @@ function updateDue(value) {
   }
 
   &__notes {
+    opacity: 0.3;
     margin-top: 20px;
     font-size: 12px;
     color: var(--grey-color);

--- a/src/components/settings/hostingPreferences/PricesSection.vue
+++ b/src/components/settings/hostingPreferences/PricesSection.vue
@@ -39,22 +39,22 @@ const emit = defineEmits(['update:price'])
 const prices = computed(() => [
   {
     label: t('$.cpu'),
-    value: props.data.cpu,
+    value: props.data.cpu || 0,
     unit: 'HF per min',
     prop: 'cpu',
     isDisabled: true
   },
   {
     label: t('$.storage'),
-    value: props.data.storage,
-    unit: 'HF per GB',
+    value: props.data.storage ? formatPrice(props.data.storage).value : 0,
+    unit: props.data.storage ? formatPrice(props.data.storage).unit : '',
     prop: 'storage',
     isDisabled: true
   },
   {
     label: t('$.bandwidth'),
-    value: props.data.bandwidth,
-    unit: 'HF per GB',
+    value: props.data.bandwidth ? formatPrice(props.data.bandwidth).value : 0,
+    unit: props.data.bandwidth ? formatPrice(props.data.bandwidth).unit : '',
     prop: 'bandwidth',
     isDisabled: true
   }
@@ -62,6 +62,39 @@ const prices = computed(() => [
 
 function updatePrice({ prop, value }) {
   emit('update:price', { prop, value })
+}
+
+function formatPrice(pricePerByte) {
+  if (isNaN(pricePerByte)) {
+    return '-- GB'
+  }
+
+  if (pricePerByte === 0) {
+    return '0 GB'
+  }
+
+  const k = 1024
+  const sizes = ['byte', 'kB', 'MB', 'GB', 'TB']
+
+  // eslint-disable-next-line no-magic-numbers
+  const zerosAfterDecimal = -Math.floor(Math.log(pricePerByte) / Math.log(10))
+
+  if (zerosAfterDecimal <= 0) {
+    return {
+      // eslint-disable-next-line no-magic-numbers
+      value: parseFloat(pricePerByte).toFixed(0),
+      unit: `HF per ${sizes[0]}`
+    }
+  }
+
+  // eslint-disable-next-line no-magic-numbers
+  const unitIndex = Math.floor(zerosAfterDecimal / 3)
+
+  return {
+    // eslint-disable-next-line no-magic-numbers
+    value: parseFloat((pricePerByte * Math.pow(k, unitIndex)).toFixed(2)),
+    unit: `HF per ${sizes[unitIndex]}`
+  }
 }
 </script>
 

--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -164,7 +164,6 @@ const HposInterface = {
     }
   },
 
-  // TODO: Convert into a zome_call like for `setHostPreferences` once abstract and modularize the rust duration type for use in js
   getHostPreferences: async () => {
     try {
       return await hposHolochainCall({
@@ -173,7 +172,7 @@ const HposInterface = {
       })
     } catch (error) {
       console.error('getHostEarnings encountered an error: ', error)
-      return { error }
+      throw error
     }
   },
 

--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -164,6 +164,41 @@ const HposInterface = {
     }
   },
 
+  // TODO: Convert into a zome_call like for `setHostPreferences` once abstract and modularize the rust duration type fr use in js
+  getHostPreferences: async () => {
+    try {
+      return await hposHolochainCall({
+        method: 'get',
+        path: '/host_preferences'
+      })
+    } catch (error) {
+      console.error('getHostEarnings encountered an error: ', error)
+      return { error }
+    }
+  },
+
+  async setHostPreferences(hostPreferences) {
+    try {
+      const params = {
+        appId: localStorage.getItem(kCoreAppVersionLSKey),
+        roleId: 'core-app',
+        zomeName: 'hha',
+        fnName: 'set_happ_preferences',
+        payload: hostPreferences
+      }
+
+      await hposHolochainCall({
+        method: 'post',
+        path: '/zome_call',
+        params
+      })
+
+      return true
+    } catch (error) {
+      return false
+    }
+  },
+
   checkAuth: async (email, password, authToken) => {
     const keypair = await getHpAdminKeypair(email, password)
 

--- a/src/interfaces/HposInterface.js
+++ b/src/interfaces/HposInterface.js
@@ -164,7 +164,7 @@ const HposInterface = {
     }
   },
 
-  // TODO: Convert into a zome_call like for `setHostPreferences` once abstract and modularize the rust duration type fr use in js
+  // TODO: Convert into a zome_call like for `setHostPreferences` once abstract and modularize the rust duration type for use in js
   getHostPreferences: async () => {
     try {
       return await hposHolochainCall({

--- a/src/pages/HostingPreferences.vue
+++ b/src/pages/HostingPreferences.vue
@@ -21,25 +21,28 @@ import PrimaryLayout from 'components/PrimaryLayout.vue'
 import HAppSelectionSection from 'components/settings/hostingPreferences/HAppSelectionSection'
 import InvoicesSection from 'components/settings/hostingPreferences/InvoicesSection.vue'
 import PricesSection from 'components/settings/hostingPreferences/PricesSection.vue'
+import { reactive, ref, computed, onMounted } from 'vue'
 import { usePreferencesStore } from '@/store/preferences'
-import { reactive, computed, onMounted} from 'vue'
 
 const preferencesStore = usePreferencesStore()
 
+const isLoading = ref(false)
+const isError = ref(false)
+
 const localInvoicesSettings = reactive({
   frequency: {
-    amount: 100,
-    period: 7
+    amount: 0,
+    period: 0
   },
   due: {
-    period: 7
-  },
+    period: 0
+  }
 })
 
 const localPricesSettings = reactive({
-  cpu: 100,
-  storage: 100,
-  bandwidth: 100,
+  cpu: 0,
+  storage: 0,
+  bandwidth: 0
 })
 
 function updateFrequency(value) {
@@ -65,14 +68,14 @@ const invoicesSettings = computed(() => ({
 }))
 
 // NOTE: This can currently only be called only once - ensure all values are present before invoking
-async function setHostSettings () {
+async function setHostSettings() {
   if (isError.value) {
     isError.value = false
   }
 
   isLoading.value = true
 
-  const isSuccess = await preferencesStore.updateHoloFuelProfile({ 
+  const isSuccess = await preferencesStore.updateHoloFuelProfile({
     invoicesSettings,
     pricesSettings
   })
@@ -91,11 +94,10 @@ async function getHostPreferences() {
 }
 
 onMounted(async () => {
-  if (!(invoicesSettings.value && pricesSettings.value) ) {
+  if (!preferencesStore.isLoaded) {
     await getHostPreferences()
   }
 })
-
 </script>
 
 <style lang="scss" scoped>

--- a/src/pages/HostingPreferences.vue
+++ b/src/pages/HostingPreferences.vue
@@ -61,22 +61,17 @@ function updatePrice({ prop, value }) {
 }
 
 // NOTE: This can currently only be called only once - ensure all values are present before invoking
-function setHostSettings (value) {
+function setHostSettings () {
   if (isError.value) {
     isError.value = false
   }
 
   isLoading.value = true
 
-  const invoicesSettings = {
-    frequency: value,
-    // NB: Mock due period while it remains unimplemented in DNAs
-    due: {
-      period: 7
-    }
-  }
-
-  const isSuccess = await preferencesStore.updateHoloFuelProfile({ invoicesSettings })
+  const isSuccess = await preferencesStore.updateHoloFuelProfile({ 
+    invoicesSettings: this.pricesSettings,
+    pricesSettings: this.pricesSettings
+  })
 
   isLoading.value = false
 

--- a/src/store/preferences.js
+++ b/src/store/preferences.js
@@ -24,7 +24,7 @@ export const usePreferencesStore = defineStore('preferences', {
       const { 
         max_fuel_before_invoice: amount,
         max_time_before_invoice: duration_threshold, // hos-holochain-api translates duratin -> days
-        // max_time_before_invoice_expiration: deadline, // TODO: Add this feild in SL and HF
+        // max_time_before_invoice_expiration: deadline, // TODO: Add this field in SL and HF
         price_compute: cpu,
         price_storage: storage,
         price_bandwidth: bandwidth
@@ -67,7 +67,7 @@ export const usePreferencesStore = defineStore('preferences', {
         price_storage: priceSettings.storage,
         price_bandwidth: priceSettings.bandwidth,
         max_time_before_invoice: invoiceSettings.frequency.period,
-        // max_time_before_invoice_expiration: invoiceSettings.due.period, // TODO: Add this feild in SL and HF
+        // max_time_before_invoice_expiration: invoiceSettings.due.period, // TODO: Add this field in SL and HF
       })
 
       if (result) {

--- a/src/store/preferences.js
+++ b/src/store/preferences.js
@@ -1,0 +1,106 @@
+import { defineStore } from 'pinia'
+import HposInterface from 'src/interfaces/HposInterface'
+
+export const usePreferencesStore = defineStore('preferences', {
+  state: () => ({
+    priceSettings: {
+      cpu: 0,
+      storage: 0,
+      bandwidth: 0
+    },
+    invoiceSettings: {
+      frequency: {
+        amount: 0, // in fuel type
+        period: 0 // in duration days
+      },
+      due: {
+        period: 7 // in duration days
+      }
+    },
+  }),
+
+  actions: {
+    async getHostPreferences({ happ_id }) {
+      const { 
+        max_fuel_before_invoice: amount,
+        max_time_before_invoice: duration_threshold, // hos-holochain-api translates duratin -> days
+        // max_time_before_invoice_expiration: deadline, // TODO: Add this feild in SL and HF
+        price_compute: cpu,
+        price_storage: storage,
+        price_bandwidth: bandwidth
+      } = await HposInterface.getHostPreferences(happ_id)
+      
+      if (cpu && storage && bandwidth) {
+        this.priceSettings = {
+          cpu,
+          storage,
+          bandwidth
+        }
+      }
+
+      if (amount && duration_threshold) {
+        // NB: This value is not implmented in DNAs, return mock for now
+        const deadline = this.invoiceSettings.due.period
+
+        this.invoiceSettings = {
+          frequency: {
+            amount,
+            period: duration_threshold
+          },
+          due: {
+            period: deadline
+          }
+        }
+      }
+    },
+
+    // FYI: This can only be set once atm (future requests will error out)
+    async setHostPreferences({
+      happ_id,
+      priceSettings = this.priceSettings,
+      invoiceSettings = this.invoiceSettings,
+    }) {
+      const result = await HposInterface.updateHostPreferences({
+        happ_id,
+        max_fuel_before_invoice: invoiceSettings.frequency.amount,
+        price_compute: priceSettings.cpu,
+        price_storage: priceSettings.storage,
+        price_bandwidth: priceSettings.bandwidth,
+        max_time_before_invoice: invoiceSettings.frequency.period,
+        // max_time_before_invoice_expiration: invoiceSettings.due.period, // TODO: Add this feild in SL and HF
+      })
+
+      if (result) {
+        const  { 
+          max_fuel_before_invoice: amount,
+          max_time_before_invoice: duration_threshold, // hos-holochain-api translates duratin -> days
+          // max_time_before_invoice_expiration: deadline, // TODO: Add this feild in SL and HF
+          price_compute: cpu,
+          price_storage: storage,
+          price_bandwidth: bandwidth
+        } = result
+
+        this.priceSettings = {
+          cpu,
+          storage,
+          bandwidth
+        }
+
+        // NB: This value is not implmented in DNAs, return mock for now
+        const deadline = invoiceSettings.due.period
+
+        this.invoiceSettings = {
+          frequency: {
+            amount,
+            period: duration_threshold
+          },
+          due: {
+            period: deadline
+          }
+        }
+      }
+
+      return !!result
+    }
+  }
+})

--- a/src/store/preferences.js
+++ b/src/store/preferences.js
@@ -4,18 +4,18 @@ import HposInterface from 'src/interfaces/HposInterface'
 export const usePreferencesStore = defineStore('preferences', {
   state: () => ({
     isLoaded: false,
-    priceSettings: {
+    pricesSettings: {
       cpu: 0,
       storage: 0,
       bandwidth: 0
     },
-    invoiceSettings: {
+    invoicesSettings: {
       frequency: {
         amount: 0, // in fuel type
-        period: 0 // in duration days
+        period: 'N/A' // in duration days
       },
       due: {
-        period: 7 // in duration days
+        period: 'N/A' // in duration days
       }
     }
   }),
@@ -24,29 +24,28 @@ export const usePreferencesStore = defineStore('preferences', {
     async getHostPreferences() {
       const {
         max_fuel_before_invoice: amount,
-        max_time_before_invoice: duration_threshold, // hos-holochain-api translates duration -> days
-        // max_time_before_invoice_expiration: deadline, // TODO: Add this field in SL and HF
+        max_time_before_invoice: durationThreshold,
         price_compute: cpu,
         price_storage: storage,
         price_bandwidth: bandwidth
       } = await HposInterface.getHostPreferences()
 
       if (cpu && storage && bandwidth) {
-        this.priceSettings = {
+        this.pricesSettings = {
           cpu,
           storage,
-          bandwidth
+          bandwidth: 1
         }
       }
 
-      if (amount && duration_threshold) {
+      if (amount && durationThreshold) {
         // NB: This value is not implemented in DNAs, return mock for now
-        const deadline = this.invoiceSettings.due.period
+        const deadline = 'N/A'
 
-        this.invoiceSettings = {
+        this.invoicesSettings = {
           frequency: {
             amount,
-            period: duration_threshold
+            period: 'N/A' // durationThreshold
           },
           due: {
             period: deadline
@@ -55,55 +54,6 @@ export const usePreferencesStore = defineStore('preferences', {
       }
 
       this.isLoaded = true
-    },
-
-    // FYI: This can only be set once atm (future requests will error out)
-    async setHostPreferences({
-      happ_id,
-      priceSettings = this.priceSettings,
-      invoiceSettings = this.invoiceSettings
-    }) {
-      const result = await HposInterface.updateHostPreferences({
-        happ_id,
-        max_fuel_before_invoice: invoiceSettings.frequency.amount,
-        price_compute: priceSettings.cpu,
-        price_storage: priceSettings.storage,
-        price_bandwidth: priceSettings.bandwidth,
-        max_time_before_invoice: invoiceSettings.frequency.period
-        // max_time_before_invoice_expiration: invoiceSettings.due.period, // TODO: Add this field in SL and HF
-      })
-
-      if (result) {
-        const {
-          max_fuel_before_invoice: amount,
-          max_time_before_invoice: duration_threshold, // hos-holochain-api translates duration -> days
-          // max_time_before_invoice_expiration: deadline, // TODO: Add this feild in SL and HF
-          price_compute: cpu,
-          price_storage: storage,
-          price_bandwidth: bandwidth
-        } = result
-
-        this.priceSettings = {
-          cpu,
-          storage,
-          bandwidth
-        }
-
-        // NB: This value is not implemented in DNAs, return mock for now
-        const deadline = invoiceSettings.due.period
-
-        this.invoiceSettings = {
-          frequency: {
-            amount,
-            period: duration_threshold
-          },
-          due: {
-            period: deadline
-          }
-        }
-      }
-
-      return !!result
     }
   }
 })

--- a/src/store/preferences.js
+++ b/src/store/preferences.js
@@ -3,6 +3,7 @@ import HposInterface from 'src/interfaces/HposInterface'
 
 export const usePreferencesStore = defineStore('preferences', {
   state: () => ({
+    isLoaded: false,
     priceSettings: {
       cpu: 0,
       storage: 0,
@@ -16,20 +17,20 @@ export const usePreferencesStore = defineStore('preferences', {
       due: {
         period: 7 // in duration days
       }
-    },
+    }
   }),
 
   actions: {
-    async getHostPreferences({ happ_id }) {
-      const { 
+    async getHostPreferences() {
+      const {
         max_fuel_before_invoice: amount,
-        max_time_before_invoice: duration_threshold, // hos-holochain-api translates duratin -> days
+        max_time_before_invoice: duration_threshold, // hos-holochain-api translates duration -> days
         // max_time_before_invoice_expiration: deadline, // TODO: Add this field in SL and HF
         price_compute: cpu,
         price_storage: storage,
         price_bandwidth: bandwidth
-      } = await HposInterface.getHostPreferences(happ_id)
-      
+      } = await HposInterface.getHostPreferences()
+
       if (cpu && storage && bandwidth) {
         this.priceSettings = {
           cpu,
@@ -39,7 +40,7 @@ export const usePreferencesStore = defineStore('preferences', {
       }
 
       if (amount && duration_threshold) {
-        // NB: This value is not implmented in DNAs, return mock for now
+        // NB: This value is not implemented in DNAs, return mock for now
         const deadline = this.invoiceSettings.due.period
 
         this.invoiceSettings = {
@@ -52,13 +53,15 @@ export const usePreferencesStore = defineStore('preferences', {
           }
         }
       }
+
+      this.isLoaded = true
     },
 
     // FYI: This can only be set once atm (future requests will error out)
     async setHostPreferences({
       happ_id,
       priceSettings = this.priceSettings,
-      invoiceSettings = this.invoiceSettings,
+      invoiceSettings = this.invoiceSettings
     }) {
       const result = await HposInterface.updateHostPreferences({
         happ_id,
@@ -66,14 +69,14 @@ export const usePreferencesStore = defineStore('preferences', {
         price_compute: priceSettings.cpu,
         price_storage: priceSettings.storage,
         price_bandwidth: priceSettings.bandwidth,
-        max_time_before_invoice: invoiceSettings.frequency.period,
+        max_time_before_invoice: invoiceSettings.frequency.period
         // max_time_before_invoice_expiration: invoiceSettings.due.period, // TODO: Add this field in SL and HF
       })
 
       if (result) {
-        const  { 
+        const {
           max_fuel_before_invoice: amount,
-          max_time_before_invoice: duration_threshold, // hos-holochain-api translates duratin -> days
+          max_time_before_invoice: duration_threshold, // hos-holochain-api translates duration -> days
           // max_time_before_invoice_expiration: deadline, // TODO: Add this feild in SL and HF
           price_compute: cpu,
           price_storage: storage,
@@ -86,7 +89,7 @@ export const usePreferencesStore = defineStore('preferences', {
           bandwidth
         }
 
-        // NB: This value is not implmented in DNAs, return mock for now
+        // NB: This value is not implemented in DNAs, return mock for now
         const deadline = invoiceSettings.due.period
 
         this.invoiceSettings = {


### PR DESCRIPTION
### Updates:
 - add hosting preference endpoints to hpos-interface
 - add preferences store
 - update dynamic state logic on the preferences page

<img width="1382" alt="Screenshot 2022-11-04 at 16 49 17" src="https://user-images.githubusercontent.com/17565389/200018700-264b8192-8b74-4820-8f7d-1fad2e8f596f.png">
