### PR TITLE
Fix/qa findings

### DIFF
--- a/src/components/dashboard/HappsCard.vue
+++ b/src/components/dashboard/HappsCard.vue
@@ -18,9 +18,10 @@
         :key="happ.id"
         class="top-happ-row"
       >
-        <div class="logo">
-          <MissingLogoExIcon class="ex-icon" />
-        </div>
+        <HAppImage
+          :happ="happ"
+          size="37px"
+        />
         <div class="top-happ-details">
           <div class="card-info-row">
             {{ happ.name }}
@@ -35,8 +36,8 @@
 </template>
 
 <script setup>
-import BaseCard from '@uicommon/components/BaseCard'
-import MissingLogoExIcon from 'components/icons/MissingLogoExIcon'
+import BaseCard from '@uicommon/components/BaseCard.vue'
+import HAppImage from '@uicommon/components/HAppImage.vue'
 import { computed } from 'vue'
 
 const props = defineProps({
@@ -56,7 +57,7 @@ const isError = computed(() => !!props.data.error)
 const emit = defineEmits(['try-again-clicked'])
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .body {
   height: 100%;
 }
@@ -68,15 +69,6 @@ const emit = defineEmits(['try-again-clicked'])
 
 .margin-bottom {
   margin-bottom: 10px;
-}
-
-.logo {
-  border: 1px solid #e7e9ed;
-  box-sizing: border-box;
-  border-radius: 5px;
-  width: 37px;
-  height: 37px;
-  margin: 0 16px;
 }
 
 .no-happs {

--- a/src/components/dashboard/RecentPaymentsCard.vue
+++ b/src/components/dashboard/RecentPaymentsCard.vue
@@ -29,8 +29,8 @@
           </div>
         </div>
         <div class="payment-time">
-          {{ payment ? dayjs(payment.updatedAt).format('DD MMM') : '--' }}
-          {{ payment ? dayjs(payment.updatedAt).format('hh:mm') : '--' }}
+          {{ payment?.completedDate ? dayjs(payment.completedDate).format('DD MMM') : '--' }}
+          {{ payment?.completedDate ? dayjs(payment.updatedAt).format('HH:mm') : '' }}
         </div>
       </div>
     </div>
@@ -95,6 +95,7 @@ const isError = computed(() => !!props.data.error)
   font-size: 9px;
   line-height: 12px;
   margin-top: 4px;
+  margin-left: 3px;
 }
 
 .no-payments {


### PR DESCRIPTION
This PR fixes:

- hApp image resize logic
<img width="642" alt="Screenshot 2022-11-16 at 21 35 31" src="https://user-images.githubusercontent.com/17565389/202288584-ed13181e-4668-4391-bbe2-04229c5e65d9.png">

<img width="363" alt="Screenshot 2022-11-16 at 21 35 40" src="https://user-images.githubusercontent.com/17565389/202288612-0a9fd936-887c-4033-b5d4-bacf13a96590.png">

- recent payments date completed value showing `-` if not value exist
<img width="354" alt="Screenshot 2022-11-16 at 21 35 56" src="https://user-images.githubusercontent.com/17565389/202288651-a98bd468-6906-4ea5-86f5-446d0144b28c.png">
