### PR TITLE
Add available to getHostEarnings result

### DIFF
--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -55,7 +55,7 @@ const usage = {
 
 const earnings = {
   earnings: { last30days: 1343209.4, last7days: 447768.54, lastday: 34209.4 },
-  holofuel: { balance: '0' },
+  holofuel: { balance: '0', available: '0' },
   recentPayments: [
     {
       id: 1,

--- a/src/components/dashboard/HoloFuelCard.vue
+++ b/src/components/dashboard/HoloFuelCard.vue
@@ -58,7 +58,7 @@ const items = computed(() => [
   {
     label: t('holofuel.balance'),
     value:
-      props.data && Number(props.data.balance) ? formatCurrency(Number(props.data.balance)) : 0,
+      props.data && Number(props.data.available) ? formatCurrency(Number(props.data.available)) : 0,
     isActive: true
   },
   {

--- a/src/store/dashboard.js
+++ b/src/store/dashboard.js
@@ -14,7 +14,7 @@ export const useDashboardStore = defineStore('dashboard', {
     },
     hostEarnings: {
       earnings: { last30days: '0', last7days: '0', lastday: '0' },
-      holofuel: { balance: '0' },
+      holofuel: { balance: '0', available: '0' },
       recentPayments: []
     },
     hostedHapps: []


### PR DESCRIPTION
Gets `available` balance from `getHostEarnings` and uses that in the dashboard HF balance display.

Included in, and using `hpos-holochain-api` updates from, this pr: https://github.com/Holo-Host/holo-nixpkgs/pull/1431