### PR TITLE
Feature: add redemptions history table

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -433,7 +433,7 @@ module.exports = {
         }, ...kNamingConventions],
         'vue/block-spacing': 'error',
         'vue/component-tags-order': ['error', {
-          order: ['template', 'script', 'style']
+          order: ['script', 'template', 'style']
         }],
         'vue/component-name-in-template-casing': ['error', 'PascalCase', {
           registeredComponentsOnly: true,

--- a/mock-hpos-api/authUtils.js
+++ b/mock-hpos-api/authUtils.js
@@ -1,5 +1,4 @@
-import stringify from 'fast-json-stable-stringify'
-import sha512 from'js-sha512'
+const sha512 = require('js-sha512')
 
 // there's some duplication between this file and src/utils/keyManagement.ts
 

--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -432,10 +432,11 @@ const mockRedemptionHistoryData = [
     id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE63',
     createdDate: createDate(1, -1),
     requestedAmount: '1421002.0398',
-    completedAmount: '1421002.0398',
-    redemptionAmount: '1421002.0398',
+    completedAmount: '1000000.00',
+    redemptionAmount: '1000000.00',
     transactionId: '0xaf88712107800f829599a220ee6ac866c9b3cc9941fc0d3e6af3f8745f76155f',
     status: 'completed',
+    isPartial: true,
   },
   {
     id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE64',
@@ -445,6 +446,7 @@ const mockRedemptionHistoryData = [
     redemptionAmount: '1421002',
     transactionId: '0xaf88712107800f829599a220ee6ac866c9b3cc9941fc0d3e6af3f8745f76155f',
     status: 'completed',
+    isPartial: false,
   },
   {
     id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE65',
@@ -454,6 +456,7 @@ const mockRedemptionHistoryData = [
     redemptionAmount: '0',
     transactionId: '',
     status: 'pending',
+    isPartial: false,
   },
   {
     id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE66',
@@ -463,6 +466,7 @@ const mockRedemptionHistoryData = [
     redemptionAmount: '0',
     transactionId: '',
     status: 'pending',
+    isPartial: false,
   },
   {
     id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE67',
@@ -472,6 +476,7 @@ const mockRedemptionHistoryData = [
     redemptionAmount: '0',
     transactionId: '',
     status: 'pending',
+    isPartial: false,
   },
   {
     id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE68',
@@ -481,6 +486,7 @@ const mockRedemptionHistoryData = [
     redemptionAmount: '0',
     transactionId: '',
     status: 'pending',
+    isPartial: false,
   }
 ]
 

--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -434,7 +434,7 @@ const mockRedemptionHistoryData = [
     requestedAmount: '1421002.0398',
     completedAmount: '1421002.0398',
     redemptionAmount: '1421002.0398',
-    transactionId: 'uhCAki0d39_k2EkZzuUEaiw03ruRYoGh05vswcLsi566MC-Nxqtj3',
+    transactionId: '0xaf88712107800f829599a220ee6ac866c9b3cc9941fc0d3e6af3f8745f76155f',
     status: 'completed',
   },
   {
@@ -443,7 +443,7 @@ const mockRedemptionHistoryData = [
     requestedAmount: '1421002',
     completedAmount: '1421002',
     redemptionAmount: '1421002',
-    transactionId: 'uhCAki0d39_k2EkZzuUEaiw03ruRYoGh05vswcLsi566MC-Nxqtj4',
+    transactionId: '0xaf88712107800f829599a220ee6ac866c9b3cc9941fc0d3e6af3f8745f76155f',
     status: 'completed',
   },
   {

--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -435,7 +435,7 @@ const mockRedemptionHistoryData = [
     completedAmount: '1421002.0398',
     redemptionAmount: '1421002.0398',
     transactionId: 'uhCAki0d39_k2EkZzuUEaiw03ruRYoGh05vswcLsi566MC-Nxqtj3',
-    status: 'Completed',
+    status: 'completed',
   },
   {
     id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE64',
@@ -444,7 +444,43 @@ const mockRedemptionHistoryData = [
     completedAmount: '1421002',
     redemptionAmount: '1421002',
     transactionId: 'uhCAki0d39_k2EkZzuUEaiw03ruRYoGh05vswcLsi566MC-Nxqtj4',
-    status: 'Completed',
+    status: 'completed',
+  },
+  {
+    id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE65',
+    createdDate: createDate(0, -2),
+    requestedAmount: '142100',
+    completedAmount: '0',
+    redemptionAmount: '0',
+    transactionId: '',
+    status: 'pending',
+  },
+  {
+    id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE66',
+    createdDate: createDate(2, -2),
+    requestedAmount: '2421002',
+    completedAmount: '0',
+    redemptionAmount: '0',
+    transactionId: '',
+    status: 'pending',
+  },
+  {
+    id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE67',
+    createdDate: createDate(2, -2),
+    requestedAmount: '3421002',
+    completedAmount: '0',
+    redemptionAmount: '0',
+    transactionId: '',
+    status: 'pending',
+  },
+  {
+    id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE68',
+    createdDate: createDate(3, -2),
+    requestedAmount: '4421002',
+    completedAmount: '0',
+    redemptionAmount: '0',
+    transactionId: '',
+    status: 'pending',
   }
 ]
 

--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -1,5 +1,5 @@
 // mock of normal hpos api responses
-import { createDate } from './utils'
+const createDate = require('./utils')
 
 /* eslint-disable no-magic-numbers */
 const happs = [
@@ -427,6 +427,27 @@ const mockPaidInvoicesData = [
   }
 ]
 
+const mockRedemptionHistoryData = [
+  {
+    id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE63',
+    createdDate: createDate(1, -1),
+    requestedAmount: '1421002.0398',
+    completedAmount: '1421002.0398',
+    redemptionAmount: '1421002.0398',
+    transactionId: 'uhCAki0d39_k2EkZzuUEaiw03ruRYoGh05vswcLsi566MC-Nxqtj3',
+    status: 'Completed',
+  },
+  {
+    id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE64',
+    createdDate: createDate(1, -2),
+    requestedAmount: '1421002',
+    completedAmount: '1421002',
+    redemptionAmount: '1421002',
+    transactionId: 'uhCAki0d39_k2EkZzuUEaiw03ruRYoGh05vswcLsi566MC-Nxqtj4',
+    status: 'Completed',
+  }
+]
+
 const holoNixpkgs = {
   holo_nixpkgs: {
     channel: {
@@ -451,7 +472,8 @@ const data = {
     '/holochain-api/v1/usage': usage,
     '/holochain-api/v1/host_earnings': earnings,
     '/holochain-api/v1/core_app_version': coreAppVersion,
-    '/holochain-api/v1/host_invoices': mockPaidInvoicesData
+    '/holochain-api/v1/host_invoices': mockPaidInvoicesData,
+    '/holochain-api/v1/redemption_history': mockRedemptionHistoryData
   },
   put: {
     '/api/v1/config': (args) => args,

--- a/mock-hpos-api/runMockHposApi.js
+++ b/mock-hpos-api/runMockHposApi.js
@@ -10,7 +10,7 @@ let port
 if (argv.port) {
   port = argv.port
 } else {
-  port = import.meta.env.VITE_HPOS_PORT
+  port = 4567
 }
 
 if (!port) {

--- a/mock-hpos-api/utils.js
+++ b/mock-hpos-api/utils.js
@@ -1,8 +1,8 @@
-import dayjs from 'dayjs'
+const dayjs = require('dayjs')
 
 const kMsInSecond = 1000
 
-export function createDate(dayOfWeek, weeksAhead = 1) {
+function createDate(dayOfWeek, weeksAhead = 1) {
   const day = new Date()
   const currentDayOfMonth = day.getDate()
   const currentDayOfWeek = day.getDay()
@@ -12,3 +12,5 @@ export function createDate(dayOfWeek, weeksAhead = 1) {
 
   return dayjs(day).valueOf() * kMsInSecond
 }
+
+module.exports = createDate

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start-mock-hpos-api-with-auth": "node mock-hpos-api/runMockHposApi.js --email test@test.com --password asasas"
   },
   "dependencies": {
+    "@heroicons/vue": "^2.0.17",
     "@holo-host/hp-admin-keypair": "^0.3.0",
     "axios": "^1.3.4",
     "body-parser": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@heroicons/vue": "^2.0.17",
     "@holo-host/hp-admin-keypair": "^0.3.0",
+    "@vueuse/components": "^9.13.0",
+    "@vueuse/core": "^9.13.0",
     "axios": "^1.3.4",
     "body-parser": "^1.20.2",
     "click-outside-vue3": "^4.0.1",

--- a/src/components/dashboard/EarningsCard.vue
+++ b/src/components/dashboard/EarningsCard.vue
@@ -33,6 +33,7 @@ const props = defineProps<{
   data: Earnings | { error: unknown }
   isLoading: boolean
 }>()
+
 const emit = defineEmits(['try-again-clicked'])
 
 const isError = computed((): boolean => isErrorPredicate(props.data) && !!props.data.error)

--- a/src/components/earnings/RedeemableHoloFuelCard.vue
+++ b/src/components/earnings/RedeemableHoloFuelCard.vue
@@ -6,7 +6,6 @@
     @try-again-clicked="emit('try-again-clicked')"
   >
     <CardHeader
-      is-disabled
       :label="$t('earnings.redeemable_holofuel')"
       :amount="props.data"
       class="redeemable-holofuel__header"
@@ -14,8 +13,7 @@
 
     <div class="redeemable-holofuel__links">
       <BaseLinkButton
-        is-disabled
-        to=""
+        :to="kRoutes.redemptionHistory.path"
         :icon="RedemptionHistoryIcon"
         :label="$t('earnings.redemption_history')"
         class="redeemable-holofuel__link"
@@ -48,6 +46,7 @@ import RightArrowIcon from '@/components/icons/FatArrowIcon.vue'
 import RedemptionHistoryIcon from '@/components/icons/RedemptionHistoryIcon.vue'
 import TransferIcon from '@/components/icons/TransferIcon.vue'
 import { useGoToHoloFuel } from '@/composables/useGoToHoloFuel'
+import { kRoutes } from '@/router'
 
 const emit = defineEmits(['try-again-clicked'])
 

--- a/src/components/earnings/RedemptionHistoryTableRow.vue
+++ b/src/components/earnings/RedemptionHistoryTableRow.vue
@@ -26,7 +26,16 @@
       is-visible-on-mobile
       is-bold
       :is-italic="props.redemption.status === 'pending'"
-    />
+    >
+      <a
+        v-if="props.redemption.transactionId"
+        :href="`https://goerli.etherscan.io/tx/${props.redemption.transactionId}`"
+        target="_blank"
+        class="redemption-history-table-row__transaction-link"
+      >
+        <ArrowTopRightOnSquareIcon class="redemption-history-table-row__transaction-link-icon" />
+      </a>
+    </BaseTableRowItem>
 
     <BaseTableRowItem
       :value="props.redemption.status"
@@ -37,6 +46,7 @@
 </template>
 
 <script setup lang="ts">
+import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/20/solid'
 import BaseTableRow from '@uicommon/components/BaseTableRow.vue'
 import BaseTableRowItem from '@uicommon/components/BaseTableRowItem.vue'
 import type { Redemption } from '@/interfaces/HposInterface'
@@ -60,6 +70,17 @@ const props = defineProps<{
   &__amount-unit {
     margin-left: 35px;
     margin-right: 12px;
+  }
+
+  &__transaction-link {
+    height: 22px;
+  }
+
+  &__transaction-link-icon {
+    width: 17px;
+    margin-top: 2px;
+    margin-left: 4px;
+    color: var(--grey-dark-color);
   }
 }
 </style>

--- a/src/components/earnings/RedemptionHistoryTableRow.vue
+++ b/src/components/earnings/RedemptionHistoryTableRow.vue
@@ -6,29 +6,32 @@
       :is-italic="props.redemption.status === 'pending'"
     />
 
-    <div
-      v-element-hover="onHover"
+    <td
       class="redemption-history-table-row__hf-amount"
     >
       <BaseTableRowItem
         :value="props.redemption.formattedHfAmount"
         is-bold
         :is-italic="props.redemption.status === 'pending'"
+        is-hoverable
+        @hover="showPartialInfo"
       >
         <div
           v-if="props.redemption.isPartial"
-          class="redemption-history-table-row__partial-info"
+          class="redemption-history-table-row__info"
         >
           *
-          <div
-            v-if="isPartialInfoVisible"
-            class="redemption-history-table-row__partial-info-popover"
-          >
-            Original requested amount: {{ props.redemption.formattedRequestedAmount }}
-          </div>
+          <Transition>
+            <div
+              v-if="isPartialInfoVisible"
+              class="redemption-history-table-row__info-popover redemption-history-table-row__partial-info-popover"
+            >
+              {{ $t('redemption_history.original_requested_amount', { amount: props.redemption.formattedRequestedAmount }) }}
+            </div>
+          </Transition>
         </div>
       </BaseTableRowItem>
-    </div>
+    </td>
 
     <BaseTableRowItem
       :value="props.redemption.formattedRedemptionAmount"
@@ -36,8 +39,26 @@
       is-visible-on-mobile
       :is-italic="props.redemption.status === 'pending'"
       align="end"
+      is-hoverable
+      @hover="showTransactionPrice"
     >
-      <span class="redemption-history-table-row__amount-unit">HOT</span>
+      <span
+        v-if="props.redemption.formattedRedemptionAmount"
+        class="redemption-history-table-row__amount-unit"
+      >
+        HOT
+      </span>
+
+      <div class="redemption-history-table-row__info">
+        <Transition>
+          <div
+            v-if="isPriceVisible"
+            class="redemption-history-table-row__info-popover redemption-history-table-row__price-info-popover"
+          >
+            {{ $t('redemption_history.transaction_price', { hf: 1, hot: 1 }) }}
+          </div>
+        </Transition>
+      </div>
     </BaseTableRowItem>
 
     <BaseTableRowItem
@@ -68,19 +89,15 @@
 import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/20/solid'
 import BaseTableRow from '@uicommon/components/BaseTableRow.vue'
 import BaseTableRowItem from '@uicommon/components/BaseTableRowItem.vue'
-import { vElementHover } from '@vueuse/components'
 import { ref } from 'vue'
 import type { Redemption } from '@/interfaces/HposInterface'
 
 interface ExtendedRedemption extends Redemption {
-  id: string
   formattedCreatedDate: string
   formattedHfAmount: string
   formattedRequestedAmount: string
   formattedRedemptionAmount: string
   formattedTransactionId: string
-  status: string
-  isPartial: boolean
 }
 
 const props = defineProps<{
@@ -88,10 +105,17 @@ const props = defineProps<{
 }>()
 
 const isPartialInfoVisible = ref(false)
+const isPriceVisible = ref(false)
 
-function onHover(state: boolean): void {
+function showPartialInfo(state: boolean): void {
   if (props.redemption.isPartial) {
     isPartialInfoVisible.value = state
+  }
+}
+
+function showTransactionPrice(state: boolean): void {
+  if (props.redemption.formattedRedemptionAmount !== '---') {
+    isPriceVisible.value = state
   }
 }
 </script>
@@ -114,16 +138,13 @@ function onHover(state: boolean): void {
     color: var(--grey-dark-color);
   }
 
-  &__partial-info {
+  &__info {
     position: relative;
   }
 
-  &__partial-info-popover {
+  &__info-popover {
     position: absolute;
     z-index: 50;
-    right: -155px;
-    top: 20px;
-    width: 155px;
     background: var(--white-color);
     border-radius: 2px;
     font-size: 12px;
@@ -147,10 +168,32 @@ function onHover(state: boolean): void {
     }
   }
 
+  &__price-info-popover {
+    top: 15px;
+    right: -20px;
+    width: 100px;
+  }
+
+  &__partial-info-popover {
+    top: 20px;
+    right: -160px;
+    width: 160px;
+  }
+
   @media screen and (max-width: 1050px) {
     &__hf-amount {
       display: none;
     }
   }
+}
+
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 150ms ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
 }
 </style>

--- a/src/components/earnings/RedemptionHistoryTableRow.vue
+++ b/src/components/earnings/RedemptionHistoryTableRow.vue
@@ -3,16 +3,20 @@
     <BaseTableRowItem
       :value="props.redemption.formattedCreatedDate"
       is-visible-on-mobile
+      :is-italic="props.redemption.status === 'pending'"
     />
 
     <BaseTableRowItem
-      :value="props.redemption.formattedCompletedAmount"
+      :value="props.redemption.formattedHfAmount"
       is-bold
+      :is-italic="props.redemption.status === 'pending'"
     />
 
     <BaseTableRowItem
       :value="props.redemption.formattedRedemptionAmount"
       is-bold
+      :is-italic="props.redemption.status === 'pending'"
+      align="end"
     >
       <span class="redemption-history-table-row__amount-unit">HOT</span>
     </BaseTableRowItem>
@@ -21,12 +25,13 @@
       :value="props.redemption.formattedTransactionId"
       is-visible-on-mobile
       is-bold
-      align="end"
+      :is-italic="props.redemption.status === 'pending'"
     />
 
     <BaseTableRowItem
       :value="props.redemption.status"
       is-visible-on-mobile
+      :is-italic="props.redemption.status === 'pending'"
     />
   </BaseTableRow>
 </template>
@@ -39,7 +44,7 @@ import type { Redemption } from '@/interfaces/HposInterface'
 interface ExtendedRedemption extends Redemption {
   id: string
   formattedCreatedDate: string
-  formattedCompletedAmount: string
+  formattedHfAmount: string
   formattedRedemptionAmount: string
   formattedTransactionId: string
   status: string
@@ -54,6 +59,7 @@ const props = defineProps<{
 .redemption-history-table-row {
   &__amount-unit {
     margin-left: 35px;
+    margin-right: 12px;
   }
 }
 </style>

--- a/src/components/earnings/RedemptionHistoryTableRow.vue
+++ b/src/components/earnings/RedemptionHistoryTableRow.vue
@@ -1,3 +1,38 @@
+<script setup lang="ts">
+import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/20/solid'
+import BaseTableRow from '@uicommon/components/BaseTableRow.vue'
+import BaseTableRowItem from '@uicommon/components/BaseTableRowItem.vue'
+import { ref } from 'vue'
+import type { Redemption } from '@/interfaces/HposInterface'
+
+interface ExtendedRedemption extends Redemption {
+  formattedCreatedDate: string
+  formattedHfAmount: string
+  formattedRequestedAmount: string
+  formattedRedemptionAmount: string
+  formattedTransactionId: string
+}
+
+const props = defineProps<{
+  redemption: ExtendedRedemption
+}>()
+
+const isPartialInfoVisible = ref(false)
+const isPriceVisible = ref(false)
+
+function showPartialInfo(state: boolean): void {
+  if (props.redemption.isPartial) {
+    isPartialInfoVisible.value = state
+  }
+}
+
+function showTransactionPrice(state: boolean): void {
+  if (props.redemption.formattedRedemptionAmount !== '---') {
+    isPriceVisible.value = state
+  }
+}
+</script>
+
 <template>
   <BaseTableRow>
     <BaseTableRowItem
@@ -84,41 +119,6 @@
     />
   </BaseTableRow>
 </template>
-
-<script setup lang="ts">
-import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/20/solid'
-import BaseTableRow from '@uicommon/components/BaseTableRow.vue'
-import BaseTableRowItem from '@uicommon/components/BaseTableRowItem.vue'
-import { ref } from 'vue'
-import type { Redemption } from '@/interfaces/HposInterface'
-
-interface ExtendedRedemption extends Redemption {
-  formattedCreatedDate: string
-  formattedHfAmount: string
-  formattedRequestedAmount: string
-  formattedRedemptionAmount: string
-  formattedTransactionId: string
-}
-
-const props = defineProps<{
-  redemption: ExtendedRedemption
-}>()
-
-const isPartialInfoVisible = ref(false)
-const isPriceVisible = ref(false)
-
-function showPartialInfo(state: boolean): void {
-  if (props.redemption.isPartial) {
-    isPartialInfoVisible.value = state
-  }
-}
-
-function showTransactionPrice(state: boolean): void {
-  if (props.redemption.formattedRedemptionAmount !== '---') {
-    isPriceVisible.value = state
-  }
-}
-</script>
 
 <style lang="scss" scoped>
 .redemption-history-table-row {

--- a/src/components/earnings/RedemptionHistoryTableRow.vue
+++ b/src/components/earnings/RedemptionHistoryTableRow.vue
@@ -1,0 +1,59 @@
+<template>
+  <BaseTableRow>
+    <BaseTableRowItem
+      :value="props.redemption.formattedCreatedDate"
+      is-visible-on-mobile
+    />
+
+    <BaseTableRowItem
+      :value="props.redemption.formattedCompletedAmount"
+      is-bold
+    />
+
+    <BaseTableRowItem
+      :value="props.redemption.formattedRedemptionAmount"
+      is-bold
+    >
+      <span class="redemption-history-table-row__amount-unit">HOT</span>
+    </BaseTableRowItem>
+
+    <BaseTableRowItem
+      :value="props.redemption.formattedTransactionId"
+      is-visible-on-mobile
+      is-bold
+      align="end"
+    />
+
+    <BaseTableRowItem
+      :value="props.redemption.status"
+      is-visible-on-mobile
+    />
+  </BaseTableRow>
+</template>
+
+<script setup lang="ts">
+import BaseTableRow from '@uicommon/components/BaseTableRow.vue'
+import BaseTableRowItem from '@uicommon/components/BaseTableRowItem.vue'
+import type { Redemption } from '@/interfaces/HposInterface'
+
+interface ExtendedRedemption extends Redemption {
+  id: string
+  formattedCreatedDate: string
+  formattedCompletedAmount: string
+  formattedRedemptionAmount: string
+  formattedTransactionId: string
+  status: string
+}
+
+const props = defineProps<{
+  redemption: ExtendedRedemption
+}>()
+</script>
+
+<style lang="scss" scoped>
+.redemption-history-table-row {
+  &__amount-unit {
+    margin-left: 35px;
+  }
+}
+</style>

--- a/src/components/earnings/RedemptionHistoryTableRow.vue
+++ b/src/components/earnings/RedemptionHistoryTableRow.vue
@@ -6,8 +6,10 @@
       :is-italic="props.redemption.status === 'pending'"
     />
 
-
-    <div v-element-hover="onHover">
+    <div
+      v-element-hover="onHover"
+      class="redemption-history-table-row__hf-amount"
+    >
       <BaseTableRowItem
         :value="props.redemption.formattedHfAmount"
         is-bold
@@ -22,16 +24,16 @@
             v-if="isPartialInfoVisible"
             class="redemption-history-table-row__partial-info-popover"
           >
-            Requested amount: {{ props.redemption.formattedRequestedAmount }}
+            Original requested amount: {{ props.redemption.formattedRequestedAmount }}
           </div>
         </div>
       </BaseTableRowItem>
     </div>
 
-
     <BaseTableRowItem
       :value="props.redemption.formattedRedemptionAmount"
       is-bold
+      is-visible-on-mobile
       :is-italic="props.redemption.status === 'pending'"
       align="end"
     >
@@ -119,9 +121,9 @@ function onHover(state: boolean): void {
   &__partial-info-popover {
     position: absolute;
     z-index: 50;
-    right: -120px;
+    right: -155px;
     top: 20px;
-    width: 120px;
+    width: 155px;
     background: var(--white-color);
     border-radius: 2px;
     font-size: 12px;
@@ -142,6 +144,12 @@ function onHover(state: boolean): void {
       border-style: solid;
       border-width: 0 6px 6px 6px;
       border-color: transparent transparent white transparent;
+    }
+  }
+
+  @media screen and (max-width: 1050px) {
+    &__hf-amount {
+      display: none;
     }
   }
 }

--- a/src/components/earnings/RedemptionHistoryTableRow.vue
+++ b/src/components/earnings/RedemptionHistoryTableRow.vue
@@ -6,11 +6,28 @@
       :is-italic="props.redemption.status === 'pending'"
     />
 
-    <BaseTableRowItem
-      :value="props.redemption.formattedHfAmount"
-      is-bold
-      :is-italic="props.redemption.status === 'pending'"
-    />
+
+    <div v-element-hover="onHover">
+      <BaseTableRowItem
+        :value="props.redemption.formattedHfAmount"
+        is-bold
+        :is-italic="props.redemption.status === 'pending'"
+      >
+        <div
+          v-if="props.redemption.isPartial"
+          class="redemption-history-table-row__partial-info"
+        >
+          *
+          <div
+            v-if="isPartialInfoVisible"
+            class="redemption-history-table-row__partial-info-popover"
+          >
+            Requested amount: {{ props.redemption.formattedRequestedAmount }}
+          </div>
+        </div>
+      </BaseTableRowItem>
+    </div>
+
 
     <BaseTableRowItem
       :value="props.redemption.formattedRedemptionAmount"
@@ -49,20 +66,32 @@
 import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/20/solid'
 import BaseTableRow from '@uicommon/components/BaseTableRow.vue'
 import BaseTableRowItem from '@uicommon/components/BaseTableRowItem.vue'
+import { vElementHover } from '@vueuse/components'
+import { ref } from 'vue'
 import type { Redemption } from '@/interfaces/HposInterface'
 
 interface ExtendedRedemption extends Redemption {
   id: string
   formattedCreatedDate: string
   formattedHfAmount: string
+  formattedRequestedAmount: string
   formattedRedemptionAmount: string
   formattedTransactionId: string
   status: string
+  isPartial: boolean
 }
 
 const props = defineProps<{
   redemption: ExtendedRedemption
 }>()
+
+const isPartialInfoVisible = ref(false)
+
+function onHover(state: boolean): void {
+  if (props.redemption.isPartial) {
+    isPartialInfoVisible.value = state
+  }
+}
 </script>
 
 <style lang="scss" scoped>
@@ -81,6 +110,39 @@ const props = defineProps<{
     margin-top: 2px;
     margin-left: 4px;
     color: var(--grey-dark-color);
+  }
+
+  &__partial-info {
+    position: relative;
+  }
+
+  &__partial-info-popover {
+    position: absolute;
+    z-index: 50;
+    right: -120px;
+    top: 20px;
+    width: 120px;
+    background: var(--white-color);
+    border-radius: 2px;
+    font-size: 12px;
+    line-height: 19px;
+    color: var(--grey-color);
+    margin-top: 1px;
+    padding: 8px;
+    cursor: pointer;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+
+    &:before {
+      position: absolute;
+      left: 7px;
+      top: -5px;
+      content: '';
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-width: 0 6px 6px 6px;
+      border-color: transparent transparent white transparent;
+    }
   }
 }
 </style>

--- a/src/interfaces/HposInterface.ts
+++ b/src/interfaces/HposInterface.ts
@@ -21,6 +21,7 @@ interface HposInterface {
   updateHoloFuelProfile: ({ nickname, avatarUrl }: UpdateHoloFuelProfilePayload) => Promise<boolean>
   getPaidInvoices: () => Promise<HposHolochainCallResponse>
   getUnpaidInvoices: () => Promise<HposHolochainCallResponse>
+  getRedemptionHistory: () => Promise<HposHolochainCallResponse>
   getCoreAppVersion: () => Promise<CoreAppVersion>
   HPOS_API_URL: string
 }
@@ -78,7 +79,7 @@ type HposHolochainCallResponse =
   | HposStatusResponse
   | HoloFuelProfileResponse
   | CoreAppVersionResponse
-  | Promise<Transaction[] | boolean>
+  | Promise<Transaction[] | Redemption[] | boolean>
   | CoreAppVersion
   | HostPreferencesResponse
 
@@ -152,6 +153,15 @@ export interface Transaction {
   proof_of_service_token: string | null
   url: string | null
   expiration_date: string
+}
+
+export interface Redemption {
+  id: string
+  createdDate: string
+  completedAmount: string
+  redemptionAmount: string
+  transactionId: string
+  status: string
 }
 
 interface Error {
@@ -594,6 +604,17 @@ export function useHposInterface(): HposInterface {
     }
   }
 
+  async function getRedemptionHistory(): Promise<HposHolochainCallResponse> {
+    try {
+      return await hposHolochainCall({
+        method: 'get',
+        path: '/redemption_history'
+      })
+    } catch (error) {
+      return false
+    }
+  }
+
   async function getCoreAppVersion(): Promise<CoreAppVersion> {
     try {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -629,6 +650,7 @@ export function useHposInterface(): HposInterface {
     updateHoloFuelProfile,
     getPaidInvoices,
     getUnpaidInvoices,
+    getRedemptionHistory,
     getCoreAppVersion,
     getHostPreferences,
     HPOS_API_URL

--- a/src/interfaces/HposInterface.ts
+++ b/src/interfaces/HposInterface.ts
@@ -162,6 +162,7 @@ export interface Redemption {
   redemptionAmount: string
   transactionId: string
   status: string
+  isPartial: boolean
 }
 
 interface Error {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -128,7 +128,9 @@ const translations = {
       redemption_amount: 'Redemption Amount',
       transaction_id: 'Transaction ID',
       status: 'Status'
-    }
+    },
+    original_requested_amount: 'Original Requested Amount: {amount}',
+    transaction_price: 'Transaction Price: {hf} HF = {hot} HOT'
   },
   settings: {
     account_display_name: 'Account Display Name',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -118,6 +118,18 @@ const translations = {
     title: 'Recent Payments',
     no_payments: 'You have no payments'
   },
+  redemption_history: {
+    errors: {
+      no_redemptions: 'You have no redemptions.'
+    },
+    headers: {
+      created: 'Date Submitted',
+      hf_amount: 'HF Amount',
+      redemption_amount: 'Redemption Amount',
+      transaction_id: 'Transaction ID',
+      status: 'Status'
+    }
+  },
   settings: {
     account_display_name: 'Account Display Name',
     device_name: 'Device Name',

--- a/src/pages/InvoicesPage.vue
+++ b/src/pages/InvoicesPage.vue
@@ -72,7 +72,8 @@ const headersMap = computed(
           key: 'happ',
           label: t('invoices.headers.happ'),
           isVisibleOnMobile: true,
-          isSortable: true
+          isSortable: true,
+          type: 'string'
         }
       ],
       [
@@ -81,7 +82,8 @@ const headersMap = computed(
           key: 'counterparty',
           label: t('invoices.headers.publisher'),
           isVisibleOnMobile: false,
-          isSortable: true
+          isSortable: true,
+          type: 'string'
         }
       ],
       [
@@ -92,7 +94,8 @@ const headersMap = computed(
             isPaidInvoices.value ? 'invoices.headers.completed' : 'invoices.headers.created'
           ),
           isVisibleOnMobile: true,
-          isSortable: true
+          isSortable: true,
+          type: 'date'
         }
       ],
       [
@@ -101,7 +104,8 @@ const headersMap = computed(
           key: 'expirationDate',
           label: t('invoices.headers.due'),
           isVisibleOnMobile: false,
-          isSortable: true
+          isSortable: true,
+          type: 'date'
         }
       ],
       [
@@ -110,7 +114,8 @@ const headersMap = computed(
           key: 'formattedId',
           label: t('invoices.headers.invoice'),
           isVisibleOnMobile: false,
-          isSortable: true
+          isSortable: true,
+          type: 'string'
         }
       ],
       [
@@ -129,7 +134,8 @@ const headersMap = computed(
           key: 'payment_status',
           label: t('invoices.headers.payment_status'),
           isVisibleOnMobile: true,
-          isSortable: false
+          isSortable: false,
+          type: 'string'
         }
       ]
     ])

--- a/src/pages/RedemptionHistoryPage.vue
+++ b/src/pages/RedemptionHistoryPage.vue
@@ -1,0 +1,156 @@
+<template>
+  <PrimaryLayout
+    :breadcrumbs="breadcrumbs"
+    data-test-redemption-history-page-layout
+  >
+    <div data-test-redemption-history-page-table>
+      <BaseTable
+        v-slot="{ items }"
+        :is-loading="isLoading"
+        :is-error="isError"
+        :headers="[...headersMap.values()]"
+        :initial-sort-by="'createdDate'"
+        :items="redemptions"
+        empty-message-translation-key="'redemption_history.errors.no_redemptions'"
+        @try-again-clicked="getRedemptionHistory"
+      >
+        <RedemptionHistoryTableRow
+          v-for="item in items"
+          :key="item.id"
+          :redemption="item"
+        />
+      </BaseTable>
+    </div>
+  </PrimaryLayout>
+</template>
+
+<script setup lang="ts">
+import BaseTable from '@uicommon/components/BaseTable.vue'
+import { formatCurrency } from '@uicommon/utils/numbers'
+import dayjs from 'dayjs'
+import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import RedemptionHistoryTableRow from '@/components/earnings/RedemptionHistoryTableRow.vue'
+import PrimaryLayout from '@/components/PrimaryLayout.vue'
+import { useEarningsStore } from '@/store/earnings'
+import type { BreadCrumb } from '@/types/types'
+
+const { t } = useI18n()
+
+const isLoading = ref(false)
+const isError = ref(false)
+
+const earningsStore = useEarningsStore()
+
+const headersMap = computed(
+  () =>
+    new Map([
+      [
+        'createdDate',
+        {
+          key: 'createdDate',
+          label: t('redemption_history.headers.created'),
+          isVisibleOnMobile: true,
+          isSortable: true,
+          type: 'date'
+        }
+      ],
+      [
+        'completedAmount',
+        {
+          key: 'completedAmount',
+          label: t('redemption_history.headers.hf_amount'),
+          isVisibleOnMobile: false,
+          isSortable: true,
+          type: 'string'
+        }
+      ],
+      [
+        'redemptionAmount',
+        {
+          key: 'redemptionAmount',
+          label: t('redemption_history.headers.redemption_amount'),
+          isVisibleOnMobile: false,
+          isSortable: true,
+          type: 'string'
+        }
+      ],
+      [
+        'transactionId',
+        {
+          key: 'transactionId',
+          label: t('redemption_history.headers.transaction_id'),
+          isVisibleOnMobile: true,
+          isSortable: true,
+          align: 'end',
+          type: 'string'
+        }
+      ],
+      [
+        'status',
+        {
+          key: 'status',
+          label: t('redemption_history.headers.status'),
+          isVisibleOnMobile: true,
+          isSortable: true,
+          type: 'string'
+        }
+      ]
+    ])
+)
+
+const kMsInSecond = 1000
+const kDefaultDateFormat = 'DD MMM YYYY'
+const kVisibleHashLength = 6
+
+const redemptions = computed(() => {
+  const rawRedemptions = earningsStore.redemptions
+
+  return Array.isArray(rawRedemptions)
+    ? rawRedemptions.map((redemption) => ({
+      ...redemption,
+      formattedCreatedDate: dayjs(redemption.createdDate / kMsInSecond).format(
+        kDefaultDateFormat
+      ),
+      formattedCompletedAmount:
+          redemption.completedAmount && Number(redemption.completedAmount)
+            ? formatCurrency(Number(redemption.completedAmount))
+            : 0,
+      formattedRedemptionAmount:
+          redemption.redemptionAmount && Number(redemption.redemptionAmount)
+            ? formatCurrency(Number(redemption.redemptionAmount))
+            : 0,
+      formattedTransactionId: `...${redemption.transactionId.substring(
+        redemption.transactionId.length - kVisibleHashLength
+      )}`
+    }))
+    : []
+})
+
+const breadcrumbs = computed((): BreadCrumb[] => [
+  {
+    label: t('$.earnings'),
+    path: '/earnings'
+  },
+  {
+    label: t('earnings.redemption_history')
+  }
+])
+
+async function getRedemptionHistory(): Promise<void> {
+  isError.value = false
+  isLoading.value = true
+
+  const rawRedemptions = await earningsStore.getRedemptionHistory()
+
+  isLoading.value = false
+
+  if (!rawRedemptions) {
+    isError.value = true
+  }
+}
+
+onMounted(async (): Promise<void> => {
+  await getRedemptionHistory()
+})
+</script>

--- a/src/pages/RedemptionHistoryPage.vue
+++ b/src/pages/RedemptionHistoryPage.vue
@@ -4,13 +4,16 @@
     :breadcrumbs="breadcrumbs"
     data-test-redemption-history-page-layout
   >
-    <div data-test-redemption-history-page-table>
+    <div
+      class="redemption-history-page__table"
+      data-test-redemption-history-page-table
+    >
       <BaseTable
         v-slot="{ items }"
         :is-loading="isLoading"
         :is-error="isError"
         :headers="[...headersMap.values()]"
-        :initial-sort-by="'createdDate'"
+        initial-sort-by="createdDate"
         :items="redemptions"
         empty-message-translation-key="redemption_history.errors.no_redemptions"
         @try-again-clicked="getRedemptionHistory"
@@ -21,6 +24,10 @@
           :redemption="item"
         />
       </BaseTable>
+
+      <tr class="redemption-history-page__table-legend">
+        <td>*partial redemption</td>
+      </tr>
     </div>
   </PrimaryLayout>
 </template>
@@ -71,7 +78,7 @@ const headersMap = computed(
         {
           key: 'redemptionAmount',
           label: t('redemption_history.headers.redemption_amount'),
-          isVisibleOnMobile: false,
+          isVisibleOnMobile: true,
           isSortable: true,
           align: 'end',
           type: 'string'
@@ -123,7 +130,7 @@ const redemptions = computed(() => {
           redemption.requestedAmount && Number(redemption.requestedAmount)
             ? formatCurrency(Number(redemption.requestedAmount))
             : '---',
-			formattedRedemptionAmount:
+      formattedRedemptionAmount:
           redemption.redemptionAmount && Number(redemption.redemptionAmount)
             ? formatCurrency(Number(redemption.redemptionAmount))
             : '---',
@@ -163,3 +170,21 @@ onMounted(async (): Promise<void> => {
   await getRedemptionHistory()
 })
 </script>
+
+<style lang="scss">
+.redemption-history-page {
+  &__table {
+    position: relative;
+  }
+
+  &__table-legend {
+    position: absolute;
+    bottom: 20px;
+    left: 264px;
+    font-size: 14px;
+    line-height: 16px;
+    font-weight: 600;
+    color: var(--grey-dark-color);
+  }
+}
+</style>

--- a/src/pages/RedemptionHistoryPage.vue
+++ b/src/pages/RedemptionHistoryPage.vue
@@ -119,7 +119,11 @@ const redemptions = computed(() => {
             : redemption.requestedAmount && Number(redemption.requestedAmount)
               ? formatCurrency(Number(redemption.requestedAmount))
               : 0,
-      formattedRedemptionAmount:
+      formattedRequestedAmount:
+          redemption.requestedAmount && Number(redemption.requestedAmount)
+            ? formatCurrency(Number(redemption.requestedAmount))
+            : '---',
+			formattedRedemptionAmount:
           redemption.redemptionAmount && Number(redemption.redemptionAmount)
             ? formatCurrency(Number(redemption.redemptionAmount))
             : '---',

--- a/src/pages/RedemptionHistoryPage.vue
+++ b/src/pages/RedemptionHistoryPage.vue
@@ -1,33 +1,3 @@
-<template>
-  <PrimaryLayout
-    title="earnings.redemption_history"
-    :breadcrumbs="breadcrumbs"
-    data-test-redemption-history-page-layout
-  >
-    <div
-      class="redemption-history-page__table"
-      data-test-redemption-history-page-table
-    >
-      <BaseTable
-        v-slot="{ items }"
-        :is-loading="isLoading"
-        :is-error="isError"
-        :headers="[...headersMap.values()]"
-        initial-sort-by="createdDate"
-        :items="redemptions"
-        empty-message-translation-key="redemption_history.errors.no_redemptions"
-        @try-again-clicked="getRedemptionHistory"
-      >
-        <RedemptionHistoryTableRow
-          v-for="item in items"
-          :key="item.id"
-          :redemption="item"
-        />
-      </BaseTable>
-    </div>
-  </PrimaryLayout>
-</template>
-
 <script setup lang="ts">
 import BaseTable from '@uicommon/components/BaseTable.vue'
 import { formatCurrency } from '@uicommon/utils/numbers'
@@ -55,30 +25,30 @@ const redemptions = computed(() => {
 
   return Array.isArray(rawRedemptions)
     ? rawRedemptions.map((redemption) => ({
-      ...redemption,
-      formattedCreatedDate: dayjs(redemption.createdDate / kMsInSecond).format(
-        kDefaultDateFormat
-      ),
-      formattedHfAmount:
+        ...redemption,
+        formattedCreatedDate: dayjs(redemption.createdDate / kMsInSecond).format(
+          kDefaultDateFormat
+        ),
+        formattedHfAmount:
           redemption.completedAmount && Number(redemption.completedAmount)
             ? formatCurrency(Number(redemption.completedAmount))
             : redemption.requestedAmount && Number(redemption.requestedAmount)
-              ? formatCurrency(Number(redemption.requestedAmount))
-              : 0,
-      formattedRequestedAmount:
+            ? formatCurrency(Number(redemption.requestedAmount))
+            : 0,
+        formattedRequestedAmount:
           redemption.requestedAmount && Number(redemption.requestedAmount)
             ? formatCurrency(Number(redemption.requestedAmount))
             : '---',
-      formattedRedemptionAmount:
+        formattedRedemptionAmount:
           redemption.redemptionAmount && Number(redemption.redemptionAmount)
             ? formatCurrency(Number(redemption.redemptionAmount))
             : '---',
-      formattedTransactionId: redemption.transactionId
-        ? `...${redemption.transactionId.substring(
-          redemption.transactionId.length - kVisibleHashLength
-        )}`
-        : '---'
-    }))
+        formattedTransactionId: redemption.transactionId
+          ? `...${redemption.transactionId.substring(
+              redemption.transactionId.length - kVisibleHashLength
+            )}`
+          : '---'
+      }))
     : []
 })
 
@@ -171,6 +141,36 @@ onMounted(async (): Promise<void> => {
   await getRedemptionHistory()
 })
 </script>
+
+<template>
+  <PrimaryLayout
+    title="earnings.redemption_history"
+    :breadcrumbs="breadcrumbs"
+    data-test-redemption-history-page-layout
+  >
+    <div
+      class="redemption-history-page__table"
+      data-test-redemption-history-page-table
+    >
+      <BaseTable
+        v-slot="{ items }"
+        :is-loading="isLoading"
+        :is-error="isError"
+        :headers="[...headersMap.values()]"
+        initial-sort-by="createdDate"
+        :items="redemptions"
+        empty-message-translation-key="redemption_history.errors.no_redemptions"
+        @try-again-clicked="getRedemptionHistory"
+      >
+        <RedemptionHistoryTableRow
+          v-for="item in items"
+          :key="item.id"
+          :redemption="item"
+        />
+      </BaseTable>
+    </div>
+  </PrimaryLayout>
+</template>
 
 <style lang="scss">
 .redemption-history-page {

--- a/src/pages/RedemptionHistoryPage.vue
+++ b/src/pages/RedemptionHistoryPage.vue
@@ -11,7 +11,7 @@
         :headers="[...headersMap.values()]"
         :initial-sort-by="'createdDate'"
         :items="redemptions"
-        empty-message-translation-key="'redemption_history.errors.no_redemptions'"
+        empty-message-translation-key="redemption_history.errors.no_redemptions"
         @try-again-clicked="getRedemptionHistory"
       >
         <RedemptionHistoryTableRow

--- a/src/pages/RedemptionHistoryPage.vue
+++ b/src/pages/RedemptionHistoryPage.vue
@@ -1,5 +1,6 @@
 <template>
   <PrimaryLayout
+    title="earnings.redemption_history"
     :breadcrumbs="breadcrumbs"
     data-test-redemption-history-page-layout
   >
@@ -72,6 +73,7 @@ const headersMap = computed(
           label: t('redemption_history.headers.redemption_amount'),
           isVisibleOnMobile: false,
           isSortable: true,
+          align: 'end',
           type: 'string'
         }
       ],
@@ -82,7 +84,6 @@ const headersMap = computed(
           label: t('redemption_history.headers.transaction_id'),
           isVisibleOnMobile: true,
           isSortable: true,
-          align: 'end',
           type: 'string'
         }
       ],
@@ -112,17 +113,21 @@ const redemptions = computed(() => {
       formattedCreatedDate: dayjs(redemption.createdDate / kMsInSecond).format(
         kDefaultDateFormat
       ),
-      formattedCompletedAmount:
+      formattedHfAmount:
           redemption.completedAmount && Number(redemption.completedAmount)
             ? formatCurrency(Number(redemption.completedAmount))
-            : 0,
+            : redemption.requestedAmount && Number(redemption.requestedAmount)
+              ? formatCurrency(Number(redemption.requestedAmount))
+              : 0,
       formattedRedemptionAmount:
           redemption.redemptionAmount && Number(redemption.redemptionAmount)
             ? formatCurrency(Number(redemption.redemptionAmount))
-            : 0,
-      formattedTransactionId: `...${redemption.transactionId.substring(
-        redemption.transactionId.length - kVisibleHashLength
-      )}`
+            : '---',
+      formattedTransactionId: redemption.transactionId
+          ? `...${redemption.transactionId.substring(
+              redemption.transactionId.length - kVisibleHashLength
+            )}`
+        : '---'
     }))
     : []
 })

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,6 +7,7 @@ import HAppsPage from './pages/HAppsPage.vue'
 import HostingPreferences from './pages/HostingPreferences.vue'
 import InvoicesPage from './pages/InvoicesPage.vue'
 import LoginPage from './pages/LoginPage.vue'
+import RedemptionHistoryPage from './pages/RedemptionHistoryPage.vue'
 import SettingsPage from './pages/SettingsPage.vue'
 
 interface Routes {
@@ -19,6 +20,7 @@ interface Routes {
   paidInvoices: RouteRecordRaw
   unpaidInvoices: RouteRecordRaw
   hostingPreferences: RouteRecordRaw
+  redemptionHistory: RouteRecordRaw
   default: RouteRecordRaw
 }
 
@@ -95,6 +97,15 @@ export const kRoutes: Routes = {
     }
   },
 
+  redemptionHistory: {
+    path: '/earnings/redemption-history',
+    name: 'RedemptionHistory',
+    component: RedemptionHistoryPage,
+    meta: {
+      requiresAuth: true
+    }
+  },
+
   hostingPreferences: {
     path: '/preferences',
     name: 'HostingPreferences',
@@ -123,6 +134,7 @@ export const routerFactory = (): Router => {
       kRoutes.happs,
       kRoutes.hostingPreferences,
       kRoutes.paidInvoices,
+      kRoutes.redemptionHistory,
       kRoutes.unpaidInvoices,
       kRoutes.login
     ]

--- a/src/store/earnings.ts
+++ b/src/store/earnings.ts
@@ -1,13 +1,14 @@
 import { defineStore } from 'pinia'
-import { Earnings, Transaction, useHposInterface } from '@/interfaces/HposInterface'
-import { isTransactionsArray } from '@/types/predicates'
+import { Earnings, Redemption, Transaction, useHposInterface } from '@/interfaces/HposInterface'
+import { isRedemptionsArray, isTransactionsArray } from '@/types/predicates'
 
-const { getPaidInvoices, getUnpaidInvoices } = useHposInterface()
+const { getPaidInvoices, getUnpaidInvoices, getRedemptionHistory } = useHposInterface()
 
 interface State {
   earnings: Earnings
   paidInvoices: Transaction[]
   unpaidInvoices: Transaction[]
+  redemptions: Redemption[]
 }
 
 export const useEarningsStore = defineStore('earnings', {
@@ -18,7 +19,8 @@ export const useEarningsStore = defineStore('earnings', {
       lastday: 0
     },
     paidInvoices: [],
-    unpaidInvoices: []
+    unpaidInvoices: [],
+    redemptions: []
   }),
 
   actions: {
@@ -39,6 +41,17 @@ export const useEarningsStore = defineStore('earnings', {
       if (isTransactionsArray(unpaidInvoices)) {
         this.unpaidInvoices = unpaidInvoices
         return unpaidInvoices
+      }
+
+      return []
+    },
+
+    async getRedemptionHistory(): Promise<Redemption[]> {
+      const redemptions = await getRedemptionHistory()
+
+      if (isRedemptionsArray(redemptions)) {
+        this.redemptions = redemptions
+        return redemptions
       }
 
       return []

--- a/src/types/predicates.ts
+++ b/src/types/predicates.ts
@@ -1,4 +1,4 @@
-import type { HostPreferencesResponse, Transaction } from '@/interfaces/HposInterface'
+import type { HostPreferencesResponse, Redemption, Transaction } from '@/interfaces/HposInterface'
 import type { AdminSignature, CheckAuthResponse, Error, HoloFuelProfile } from '@/types/types'
 
 export function isAdminSignature(target: CheckAuthResponse): target is AdminSignature {
@@ -22,5 +22,9 @@ export function isNumber(target: unknown): target is number {
 }
 
 export function isTransactionsArray(target: unknown): target is Transaction[] {
+  return target !== undefined
+}
+
+export function isRedemptionsArray(target: unknown): target is Redemption[] {
   return target !== undefined
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,6 +1218,11 @@
   resolved "https://registry.yarnpkg.com/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz#c05ed35ad82df8e6ac616c68b92c2282bd083ba4"
   integrity sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==
 
+"@heroicons/vue@^2.0.17":
+  version "2.0.17"
+  resolved "https://registry.yarnpkg.com/@heroicons/vue/-/vue-2.0.17.tgz#4c23f26a715c2931c0d4fd5d2e77f8ede7a6a77b"
+  integrity sha512-M5P6Y9tmctbtv/IC1dO5vTw9xqppYxm/5BKuL4hGlxxLvaxbnTmMAoxTIzezSdYAaLh63emgOCBMa+mxphRxUQ==
+
 "@holo-host/hp-admin-keypair@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@holo-host/hp-admin-keypair/-/hp-admin-keypair-0.3.0.tgz#7906bc39167a5f9714fd02ca304007ed9a70b491"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2001,6 +2001,11 @@
     "@types/mime" "*"
     "@types/node" "*"
 
+"@types/web-bluetooth@^0.0.16":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.16.tgz#1d12873a8e49567371f2a75fe3e7f7edca6662d8"
+  integrity sha512-oh8q2Zc32S6gd/j50GowEjKLoOVOwHP/bWVjKJInBwQqdOYMdPrf1oVlelTlyfFK3CKxL1uahMDAr+vy8T7yMQ==
+
 "@typescript-eslint/eslint-plugin@^5.54.0":
   version "5.54.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.54.0.tgz#2c821ad81b2c786d142279a8292090f77d1881f4"
@@ -2257,6 +2262,37 @@
   optionalDependencies:
     "@vue/compiler-dom" "^3.0.1"
     "@vue/server-renderer" "^3.0.1"
+
+"@vueuse/components@^9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/components/-/components-9.13.0.tgz#ff909e5abdedc4123a3001c8ce88d6230b1bb5d9"
+  integrity sha512-UJ8PjQ4SGb2rsVIy9vhEc6aCu+3+2cc+xEfGNX8/M1NKIuL2Vo6c2Kc2fYFaRzWZkP8HWXu+IcwvnAzL44IEFA==
+  dependencies:
+    "@vueuse/core" "9.13.0"
+    "@vueuse/shared" "9.13.0"
+    vue-demi "*"
+
+"@vueuse/core@9.13.0", "@vueuse/core@^9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-9.13.0.tgz#2f69e66d1905c1e4eebc249a01759cf88ea00cf4"
+  integrity sha512-pujnclbeHWxxPRqXWmdkKV5OX4Wk4YeK7wusHqRwU0Q7EFusHoqNA/aPhB6KCh9hEqJkLAJo7bb0Lh9b+OIVzw==
+  dependencies:
+    "@types/web-bluetooth" "^0.0.16"
+    "@vueuse/metadata" "9.13.0"
+    "@vueuse/shared" "9.13.0"
+    vue-demi "*"
+
+"@vueuse/metadata@9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/metadata/-/metadata-9.13.0.tgz#bc25a6cdad1b1a93c36ce30191124da6520539ff"
+  integrity sha512-gdU7TKNAUVlXXLbaF+ZCfte8BjRJQWPCa2J55+7/h+yDtzw3vOoGQDRXzI6pyKyo6bXFT5/QoPE4hAknExjRLQ==
+
+"@vueuse/shared@9.13.0":
+  version "9.13.0"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-9.13.0.tgz#089ff4cc4e2e7a4015e57a8f32e4b39d096353b9"
+  integrity sha512-UrnhU+Cnufu4S6JLCPZnkWh0WwZGUp72ktOF2DFptMlOs3TOdVv8xJN53zhHGARmVOsz5KqOls09+J1NR6sBKw==
+  dependencies:
+    vue-demi "*"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"


### PR DESCRIPTION
This PR:
- enables the "Redemption History" button on the "Earnings" page

<img width="1481" alt="Screenshot 2023-04-06 at 14 11 22" src="https://user-images.githubusercontent.com/17565389/230375185-a9d78725-4a10-434c-ba3b-050074aec0c2.png">

- add a redemption history route
- shows redemption history in a table
<img width="1483" alt="Screenshot 2023-04-06 at 14 46 09" src="https://user-images.githubusercontent.com/17565389/230382632-aa216ccf-3d29-4447-889a-74d031a72bae.png">

- shows popover when hovered over amount on partial redemption
<img width="1488" alt="Screenshot 2023-04-06 at 16 08 19" src="https://user-images.githubusercontent.com/17565389/230402673-dc0e2362-886c-4057-bd25-c6df454faddb.png">

