### PR TITLE
Feature/redeem holo fuel form

### DIFF
--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -55,7 +55,7 @@ const usage = {
 
 const earnings = {
   earnings: { last30days: 1343209.4, last7days: 447768.54, lastday: 34209.4 },
-  holofuel: { balance: '0', available: '0' },
+  holofuel: { balance: '0', available: '0', redeemable: '400000000' },
   recentPayments: [
     {
       id: 1,

--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -55,7 +55,7 @@ const usage = {
 
 const earnings = {
   earnings: { last30days: 1343209.4, last7days: 447768.54, lastday: 34209.4 },
-  holofuel: { balance: '0', available: '0', redeemable: '400000000' },
+  holofuel: { balance: '0', available: '0', redeemable: '2990348.42' },
   recentPayments: [
     {
       id: 1,

--- a/src/components/dashboard/HoloFuelCard.vue
+++ b/src/components/dashboard/HoloFuelCard.vue
@@ -32,8 +32,7 @@ const items = computed((): DashboardCardItem[] => [
     value:
       !isErrorPredicate(props.data) && Number(props.data.available)
         ? formatCurrency(Number(props.data.available))
-        : 0,
-    isActive: true
+        : 0
   },
   {
     label: t('holofuel.redeemable'),
@@ -41,8 +40,7 @@ const items = computed((): DashboardCardItem[] => [
     value:
       !isErrorPredicate(props.data) && Number(props.data.redeemable)
         ? formatCurrency(Number(props.data.redeemable))
-        : 0,
-    isActive: true
+        : 0
   }
 ])
 /* eslint-enable @typescript-eslint/no-unsafe-assignment */
@@ -56,19 +54,17 @@ const items = computed((): DashboardCardItem[] => [
     @try-again-clicked="emit('try-again-clicked')"
   >
     <div
-      v-for="{ label, value, isActive } in items"
+      v-for="{ label, value } in items"
       :key="label"
       class="margin-bottom"
     >
       <span
         class="card-info-row"
-        :class="{ 'inactive': !isActive }"
       >
         {{ label }}
       </span>
       <span
         class="card-info-row bold"
-        :class="{ 'inactive': !isActive }"
       >
         {{ value }} HF
       </span>

--- a/src/components/dashboard/HoloFuelCard.vue
+++ b/src/components/dashboard/HoloFuelCard.vue
@@ -1,40 +1,9 @@
-<template>
-  <BaseCard
-    :is-loading="props.isLoading"
-    :is-error="isError"
-    :title="$t('holofuel.title')"
-    @try-again-clicked="emit('try-again-clicked')"
-  >
-    <div
-      v-for="{ label, value, isActive } in items"
-      :key="label"
-      class="margin-bottom"
-    >
-      <span
-        class="card-info-row"
-        :class="{ 'inactive': !isActive }"
-      >
-        {{ label }}
-      </span>
-      <span
-        class="card-info-row bold"
-        :class="{ 'inactive': !isActive }"
-      >
-        {{ value }} HF
-      </span>
-    </div>
-
-    <button class="redeem-button">
-      {{ $t('holofuel.redeem_holofuel') }}
-    </button>
-  </BaseCard>
-</template>
-
 <script setup lang="ts">
 import BaseCard from '@uicommon/components/BaseCard.vue'
 import { formatCurrency } from '@uicommon/utils/numbers'
 import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import router, { kRoutes } from '@/router'
 import { isError as isErrorPredicate } from '@/types/predicates'
 import type { DashboardCardItem } from '@/types/types'
 
@@ -68,14 +37,49 @@ const items = computed((): DashboardCardItem[] => [
     label: t('holofuel.redeemable'),
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     value:
-      !isErrorPredicate(props.data) && Number(props.data.available) && Number(props.data.redeemable)
+      !isErrorPredicate(props.data) && Number(props.data.redeemable)
         ? formatCurrency(Number(props.data.redeemable))
         : 0,
-    isActive: false
+    isActive: true
   }
 ])
 /* eslint-enable @typescript-eslint/no-unsafe-assignment */
 </script>
+
+<template>
+  <BaseCard
+    :is-loading="props.isLoading"
+    :is-error="isError"
+    :title="$t('holofuel.title')"
+    @try-again-clicked="emit('try-again-clicked')"
+  >
+    <div
+      v-for="{ label, value, isActive } in items"
+      :key="label"
+      class="margin-bottom"
+    >
+      <span
+        class="card-info-row"
+        :class="{ 'inactive': !isActive }"
+      >
+        {{ label }}
+      </span>
+      <span
+        class="card-info-row bold"
+        :class="{ 'inactive': !isActive }"
+      >
+        {{ value }} HF
+      </span>
+    </div>
+
+    <button
+      class="redeem-button"
+      @click="router.push({ name: kRoutes.redeemHoloFuel.name })"
+    >
+      {{ $t('holofuel.redeem_holofuel') }}
+    </button>
+  </BaseCard>
+</template>
 
 <style scoped>
 .redeem-button {
@@ -85,7 +89,7 @@ const items = computed((): DashboardCardItem[] => [
   color: white;
   font-size: 12px;
   line-height: 16px;
-  background: rgba(8, 112, 163, 0.18);
+  background: rgba(8, 112, 163);
   border-radius: 100px;
   height: 35px;
   padding: 0 25px;

--- a/src/components/dashboard/HoloFuelCard.vue
+++ b/src/components/dashboard/HoloFuelCard.vue
@@ -23,6 +23,8 @@ interface Data {
   redeemable: string
 }
 
+const canRedeem = computed((): boolean => !isError.value && Number(props.data.redeemable) > 0)
+
 /* eslint-disable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call */
 const items = computed((): DashboardCardItem[] => [
   {
@@ -73,6 +75,7 @@ const items = computed((): DashboardCardItem[] => [
     </div>
 
     <button
+      :disabled="!canRedeem"
       class="redeem-button"
       @click="router.push({ name: kRoutes.redeemHoloFuel.name })"
     >
@@ -81,7 +84,7 @@ const items = computed((): DashboardCardItem[] => [
   </BaseCard>
 </template>
 
-<style scoped>
+<style scoped lang="scss">
 .redeem-button {
   margin-top: 10px;
   align-self: center;
@@ -95,6 +98,11 @@ const items = computed((): DashboardCardItem[] => [
   padding: 0 25px;
   cursor: pointer;
   margin-bottom: 10px;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 }
 
 .margin-bottom {

--- a/src/components/earnings/RedeemHoloFuelCard.vue
+++ b/src/components/earnings/RedeemHoloFuelCard.vue
@@ -1,15 +1,53 @@
 <script setup lang="ts">
 import { ChevronLeftIcon } from '@heroicons/vue/20/solid'
+import BaseButton from '@uicommon/components/BaseButton.vue'
 import BaseCard from '@uicommon/components/BaseCard.vue'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
+import RedeemHoloFuelFormStepOne from './RedeemHoloFuelFormStepOne.vue'
+import RedeemHoloFuelFormStepTwo from './RedeemHoloFuelFormStepTwo.vue'
 import { kRoutes } from '@/router'
 
 const router = useRouter()
 
 const props = defineProps<{
-  data: string | number
+  redeemableHoloFuel: string | number
   isLoading: boolean
 }>()
+
+const amount = ref('')
+const hotAddress = ref('')
+
+const step = ref(1)
+
+const canSubmit = computed((): boolean => {
+  if (step.value === 1) {
+    return amount.value !== '' && hotAddress.value !== ''
+  }
+
+  return true
+})
+
+interface SubmitProps {
+  amount?: string
+  hotAddress?: string
+}
+
+interface StepOneProps {
+  amount?: string
+  hotAddress?: string
+}
+
+function handleSubmit(props: SubmitProps): void {
+  if (step.value === 1) {
+    step.value = 2
+  }
+}
+
+function updateData(updateProps: StepOneProps): void {
+  amount.value = updateProps.amount ?? ''
+  hotAddress.value = updateProps.hotAddress ?? ''
+}
 </script>
 
 <template>
@@ -18,13 +56,48 @@ const props = defineProps<{
       <ChevronLeftIcon class="redeem-card-header__back-icon" />
       <span
         class="redeem-card-header__back-label"
-        @click="router.push({ name: kRoutes.earnings.name })"
+        @click="step === 1 ? router.push({ name: kRoutes.earnings.name }) : step = 1"
       >
         {{ $t('$.back') }}
       </span>
     </div>
 
     <div class="redeem-card-content">
+      <div class="redeem-card-content__title">
+        {{ $t('redeem_holofuel.title') }}
+      </div>
+
+      <div class="redeem-card-content__form">
+        <RedeemHoloFuelFormStepOne
+          v-if="step === 1"
+          :redeemable-amount="Number(props.redeemableHoloFuel)"
+          @update="updateData"
+        />
+
+        <RedeemHoloFuelFormStepTwo
+          v-if="step === 2"
+          :amount="amount"
+          :hot-address="hotAddress"
+          @update="updateData"
+        />
+      </div>
+
+      <div class="redeem-card-content__buttons">
+        <span
+          class="redeem-card-content__cancel-button"
+          @click="router.push({ name: kRoutes.earnings.name })"
+        >
+          {{ $t('$.cancel') }}
+        </span>
+
+        <BaseButton
+          :is-disabled="!canSubmit"
+          class="redeem-card-content__submit-button"
+          @click="handleSubmit"
+        >
+          {{ step === 1 ? $t('$.next') : $t('redeem_holofuel.confirm_and_redeem') }}
+        </BaseButton>
+      </div>
     </div>
   </BaseCard>
 </template>
@@ -43,6 +116,36 @@ const props = defineProps<{
   &__back-label {
     margin-left: 3px;
     font-size: 14px;
+  }
+}
+
+.redeem-card-content {
+  margin-top: 30px;
+  margin-left: 200px;
+  color: var(--grey-dark-color);
+
+  &__title {
+    font-size: 22px;
+    font-weight: 700;
+  }
+
+  &__form {
+    margin-left: 2px;
+  }
+
+  &__buttons {
+    margin-top: 54px;
+    margin-left: 40px;
+  }
+
+  &__cancel-button {
+    color: var(--grey-dark-color);
+    cursor: pointer;
+    font-size: 14px;
+  }
+
+  &__submit-button {
+    margin-left: 20px;
   }
 }
 </style>

--- a/src/components/earnings/RedeemHoloFuelCard.vue
+++ b/src/components/earnings/RedeemHoloFuelCard.vue
@@ -17,36 +17,41 @@ const props = defineProps<{
 
 const amount = ref('')
 const hotAddress = ref('')
-
+const partialRedemptionTermsAccepted = ref(false)
 const step = ref(1)
 
 const canSubmit = computed((): boolean => {
   if (step.value === 1) {
     return amount.value !== '' && hotAddress.value !== ''
+  } else {
+    return partialRedemptionTermsAccepted.value
   }
-
-  return true
 })
 
-interface SubmitProps {
-  amount?: string
-  hotAddress?: string
-}
-
 interface StepOneProps {
-  amount?: string
-  hotAddress?: string
+  amount: string
+  hotAddress: string
 }
 
-function handleSubmit(props: SubmitProps): void {
+interface StepTwoProps {
+  partialRedemptionTermsAccepted: boolean
+}
+
+function handleSubmit(): void {
   if (step.value === 1) {
     step.value = 2
+  } else {
+    // TODO: submit form
   }
 }
 
-function updateData(updateProps: StepOneProps): void {
-  amount.value = updateProps.amount ?? ''
-  hotAddress.value = updateProps.hotAddress ?? ''
+function updateData(updateProps: StepOneProps & StepTwoProps): void {
+  if (step.value === 1) {
+    amount.value = updateProps.amount
+    hotAddress.value = updateProps.hotAddress
+  } else {
+    partialRedemptionTermsAccepted.value = updateProps.partialRedemptionTermsAccepted
+  }
 }
 </script>
 
@@ -78,11 +83,18 @@ function updateData(updateProps: StepOneProps): void {
           v-if="step === 2"
           :amount="amount"
           :hot-address="hotAddress"
+          :partial-redemption-terms-accepted="partialRedemptionTermsAccepted"
           @update="updateData"
         />
       </div>
 
-      <div class="redeem-card-content__buttons">
+      <div
+        class="redeem-card-content__buttons"
+        :class="[
+          { 'redeem-card-content__buttons--step-1': step === 1 },
+          { 'redeem-card-content__buttons--step-2': step === 2 }
+        ]"
+      >
         <span
           class="redeem-card-content__cancel-button"
           @click="router.push({ name: kRoutes.earnings.name })"
@@ -136,6 +148,14 @@ function updateData(updateProps: StepOneProps): void {
   &__buttons {
     margin-top: 54px;
     margin-left: 40px;
+
+    &--step-1 {
+      margin-bottom: 228px;
+    }
+
+    &--step-2 {
+      margin-bottom: 75px;
+    }
   }
 
   &__cancel-button {
@@ -146,6 +166,12 @@ function updateData(updateProps: StepOneProps): void {
 
   &__submit-button {
     margin-left: 20px;
+  }
+}
+
+@media screen and (max-width: 1050px) {
+  .redeem-card-content {
+    margin-left: 0;
   }
 }
 </style>

--- a/src/components/earnings/RedeemHoloFuelCard.vue
+++ b/src/components/earnings/RedeemHoloFuelCard.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { ChevronLeftIcon } from '@heroicons/vue/20/solid'
+import BaseCard from '@uicommon/components/BaseCard.vue'
+
+const props = defineProps<{
+  data: string | number
+  isLoading: boolean
+}>()
+</script>
+
+<template>
+  <BaseCard :is-loading="props.isLoading">
+    <div class="redeem-card-header">
+      <ChevronLeftIcon class="redeem-card-header__back-icon" />
+      <span class="redeem-card-header__back-label">{{ $t('$.back') }}</span>
+    </div>
+
+		<div class="redeem-card-content">
+
+		</div>
+  </BaseCard>
+</template>
+
+<style lang="scss" scoped>
+.redeem-card-header {
+  display: flex;
+  justify-items: center;
+  color: var(--grey-dark-color);
+
+  &__back-icon {
+    height: 16px;
+  }
+
+  &__back-label {
+    margin-left: 3px;
+    font-size: 14px;
+  }
+}
+</style>

--- a/src/components/earnings/RedeemHoloFuelCard.vue
+++ b/src/components/earnings/RedeemHoloFuelCard.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { ChevronLeftIcon } from '@heroicons/vue/20/solid'
 import BaseCard from '@uicommon/components/BaseCard.vue'
+import { useRouter } from 'vue-router'
+import { kRoutes } from '@/router'
+
+const router = useRouter()
 
 const props = defineProps<{
   data: string | number
@@ -12,12 +16,16 @@ const props = defineProps<{
   <BaseCard :is-loading="props.isLoading">
     <div class="redeem-card-header">
       <ChevronLeftIcon class="redeem-card-header__back-icon" />
-      <span class="redeem-card-header__back-label">{{ $t('$.back') }}</span>
+      <span
+        class="redeem-card-header__back-label"
+        @click="router.push({ name: kRoutes.earnings.name })"
+      >
+        {{ $t('$.back') }}
+      </span>
     </div>
 
-		<div class="redeem-card-content">
-
-		</div>
+    <div class="redeem-card-content">
+    </div>
   </BaseCard>
 </template>
 
@@ -26,6 +34,7 @@ const props = defineProps<{
   display: flex;
   justify-items: center;
   color: var(--grey-dark-color);
+  cursor: pointer;
 
   &__back-icon {
     height: 16px;

--- a/src/components/earnings/RedeemHoloFuelCard.vue
+++ b/src/components/earnings/RedeemHoloFuelCard.vue
@@ -11,7 +11,7 @@ import { kRoutes } from '@/router'
 const router = useRouter()
 
 const props = defineProps<{
-  redeemableHoloFuel: string | number
+  redeemableHoloFuel: string
   isLoading: boolean
 }>()
 
@@ -20,9 +20,11 @@ const hotAddress = ref('')
 const partialRedemptionTermsAccepted = ref(false)
 const step = ref(1)
 
+const isStepOneValid = ref(false)
+
 const canSubmit = computed((): boolean => {
   if (step.value === 1) {
-    return amount.value !== '' && hotAddress.value !== ''
+    return isStepOneValid.value
   } else {
     return partialRedemptionTermsAccepted.value
   }
@@ -77,6 +79,7 @@ function updateData(updateProps: StepOneProps & StepTwoProps): void {
           v-if="step === 1"
           :redeemable-amount="Number(props.redeemableHoloFuel)"
           @update="updateData"
+          @update:is-valid="isStepOneValid = $event"
         />
 
         <RedeemHoloFuelFormStepTwo

--- a/src/components/earnings/RedeemHoloFuelFormStepOne.vue
+++ b/src/components/earnings/RedeemHoloFuelFormStepOne.vue
@@ -18,7 +18,12 @@ const isAmountValid = computed(() => Number(amount.value) <= Number(props.redeem
 const isHotAddressValid = computed(() => /^0x[a-fA-F0-9]{40}$/.test(hotAddress.value))
 
 const canSubmit = computed(
-  () => amount.value && isAmountValid.value && hotAddress.value && isHotAddressValid.value
+  () =>
+    amount.value &&
+    Number(amount.value) > 0 &&
+    isAmountValid.value &&
+    hotAddress.value &&
+    isHotAddressValid.value
 )
 
 const formattedRedeemableHoloFuel = computed((): number =>

--- a/src/components/earnings/RedeemHoloFuelFormStepOne.vue
+++ b/src/components/earnings/RedeemHoloFuelFormStepOne.vue
@@ -8,7 +8,7 @@ const props = defineProps<{
   redeemableAmount: number
 }>()
 
-const emit = defineEmits(['update'])
+const emit = defineEmits(['update', 'update:is-valid'])
 
 const amount = ref('')
 const hotAddress = ref('')
@@ -33,8 +33,10 @@ const formattedRedeemableHoloFuel = computed((): number =>
 
 watch(
   () => canSubmit.value,
-  () => {
-    if (canSubmit.value) {
+  (value) => {
+    emit('update:is-valid', value)
+
+    if (value) {
       emit('update', { amount: amount.value, hotAddress: hotAddress.value })
     }
   }

--- a/src/components/earnings/RedeemHoloFuelFormStepOne.vue
+++ b/src/components/earnings/RedeemHoloFuelFormStepOne.vue
@@ -127,4 +127,10 @@ function activateHotAddressValidation(): void {
     width: 520px;
   }
 }
+
+@media screen and (max-width: 1050px) {
+  .form-step-one__input {
+    width: calc(100vw - 180px);
+  }
+}
 </style>

--- a/src/components/earnings/RedeemHoloFuelFormStepOne.vue
+++ b/src/components/earnings/RedeemHoloFuelFormStepOne.vue
@@ -1,0 +1,130 @@
+<script setup lang="ts">
+import BaseInput from '@uicommon/components/BaseInput.vue'
+import { EInputType } from '@uicommon/types/ui'
+import { formatCurrency } from '@uicommon/utils/numbers'
+import { ref, computed, watch } from 'vue'
+
+const props = defineProps<{
+  redeemableAmount: number
+}>()
+
+const emit = defineEmits(['update'])
+
+const amount = ref('')
+const hotAddress = ref('')
+const hotAddressValidationIsActive = ref(false)
+
+const isAmountValid = computed(() => Number(amount.value) <= Number(props.redeemableAmount))
+const isHotAddressValid = computed(() => /^0x[a-fA-F0-9]{40}$/.test(hotAddress.value))
+
+const canSubmit = computed(
+  () => amount.value && isAmountValid.value && hotAddress.value && isHotAddressValid.value
+)
+
+const formattedRedeemableHoloFuel = computed((): number =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return
+  formatCurrency(Number(props.redeemableAmount) || 0)
+)
+
+watch(
+  () => canSubmit.value,
+  () => {
+    if (canSubmit.value) {
+      emit('update', { amount: amount.value, hotAddress: hotAddress.value })
+    }
+  }
+)
+
+function activateHotAddressValidation(): void {
+  hotAddress.value = hotAddress.value.trim()
+  hotAddressValidationIsActive.value = true
+}
+</script>
+
+<template>
+  <div>
+    <div class="form-step-one__header">
+      <span>{{ $t('redeem_holofuel.you_have') }}</span>
+      <span class="form-step-one__header-value">{{ formattedRedeemableHoloFuel }} HF</span>
+      <span>{{ $t('redeem_holofuel.available_to_redeem') }}</span>
+    </div>
+
+    <div class="form-step-one__input-wrapper">
+      <span class="form-step-one__badge">1</span>
+      <div class="form-step-one__input">
+        <BaseInput
+          v-model="amount"
+          autofocus
+          :label="$t('redeem_holofuel.amount_input_label')"
+          :placeholder="$t('redeem_holofuel.amount_input_placeholder')"
+          :decimal-places="18"
+          :is-valid="isAmountValid"
+          has-errors
+          :message="isAmountValid ? '' : $t('redeem_holofuel.amount_input_error')"
+          :tip="$t('redeem_holofuel.amount_input_tip')"
+          name="amount"
+          :input-type="EInputType.number"
+          unit="HF"
+        />
+      </div>
+    </div>
+
+    <div class="form-step-one__input-wrapper">
+      <span class="form-step-one__badge">2</span>
+      <div class="form-step-one__input">
+        <BaseInput
+          v-model="hotAddress"
+          :is-valid="!hotAddressValidationIsActive || isHotAddressValid"
+          has-errors
+          :message="!hotAddressValidationIsActive || isHotAddressValid ? '' : $t('redeem_holofuel.recipient_address_input_error')"
+          :label="$t('redeem_holofuel.recipient_address_input_label')"
+          :placeholder="$t('redeem_holofuel.recipient_address_input_placeholder')"
+          name="amount"
+          @blur="activateHotAddressValidation"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.form-step-one {
+  display: flex;
+
+  &__header {
+    margin-top: 30px;
+    margin-left: 12px;
+    font-size: 16px;
+    font-weight: 700;
+
+    &-value {
+      color: var(--grey-color);
+      margin-left: 4px;
+      margin-right: 4px;
+    }
+  }
+
+  &__badge {
+    height: 25px;
+    width: 25px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: var(--primary-color);
+    color: var(--white-color);
+    font-size: 14px;
+  }
+
+  &__input-wrapper {
+    display: flex;
+    margin-top: 40px;
+  }
+
+  &__input {
+    margin-top: 4px;
+    margin-left: 12px;
+    width: 520px;
+  }
+}
+</style>

--- a/src/components/earnings/RedeemHoloFuelFormStepTwo.vue
+++ b/src/components/earnings/RedeemHoloFuelFormStepTwo.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+
+const props = defineProps<{
+  amount: number
+  hotAddress: string
+}>()
+
+const emit = defineEmits(['update'])
+
+const partialRedemptionTermsAccepted = ref(false)
+
+const canSubmit = computed(() => partialRedemptionTermsAccepted.value)
+
+watch(
+  () => canSubmit.value,
+  () => {
+    if (canSubmit.value) {
+      emit('update', { partialRedemptionTermsAccepted: partialRedemptionTermsAccepted.value })
+    }
+  }
+)
+</script>
+
+<template>
+  <div>
+    <div class="form-step-two__header">
+      <span>{{ $t('redeem_holofuel.review_and_confirm') }}</span>
+    </div>
+
+    <div class="form-step-two__item">
+      <span class="form-step-two__item-label">{{ $t('redeem_holofuel.holo_fuel_amount') }}</span>
+      <span class="form-step-two__item-value">{{ props.amount }} <span class="form-step-two__item-value--unit">HF</span></span>
+    </div>
+
+    <div class="form-step-two__item">
+      <span class="form-step-two__item-label">{{ $t('redeem_holofuel.redemption_currency') }}</span>
+      <span class="form-step-two__item-value form-step-two__item-value--unit">HOT</span>
+    </div>
+
+    <div class="form-step-two__item">
+      <span class="form-step-two__item-label">{{ $t('redeem_holofuel.redemption_amount') }}</span>
+      <span class="form-step-two__item-value">{{ props.amount }} <span class="form-step-two__item-value--unit">HOT</span></span>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.form-step-two {
+  display: flex;
+  flex-direction: column;
+
+  &__header {
+    margin-top: 30px;
+    font-size: 16px;
+    font-weight: 700;
+  }
+
+  &__item {
+    display: flex;
+    flex-direction: column;
+    margin-top: 30px;
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--grey-dark-color);
+
+    &-value {
+      margin-top: 8px;
+      &--unit {
+        color: var(--grey-color);
+      }
+    }
+  }
+}
+</style>

--- a/src/components/earnings/RedeemHoloFuelFormStepTwo.vue
+++ b/src/components/earnings/RedeemHoloFuelFormStepTwo.vue
@@ -1,25 +1,17 @@
 <script setup lang="ts">
-import { ref, computed, watch } from 'vue'
+import RedeemHoloFuelFormStepTwoItem from './RedeemHoloFuelFormStepTwoItem.vue'
 
 const props = defineProps<{
   amount: number
   hotAddress: string
+  partialRedemptionTermsAccepted: boolean
 }>()
 
 const emit = defineEmits(['update'])
 
-const partialRedemptionTermsAccepted = ref(false)
-
-const canSubmit = computed(() => partialRedemptionTermsAccepted.value)
-
-watch(
-  () => canSubmit.value,
-  () => {
-    if (canSubmit.value) {
-      emit('update', { partialRedemptionTermsAccepted: partialRedemptionTermsAccepted.value })
-    }
-  }
-)
+function updatePartialRedemptionTermsAccepted(event: Event): void {
+  emit('update', { partialRedemptionTermsAccepted: event.target?.checked })
+}
 </script>
 
 <template>
@@ -28,19 +20,40 @@ watch(
       <span>{{ $t('redeem_holofuel.review_and_confirm') }}</span>
     </div>
 
-    <div class="form-step-two__item">
-      <span class="form-step-two__item-label">{{ $t('redeem_holofuel.holo_fuel_amount') }}</span>
-      <span class="form-step-two__item-value">{{ props.amount }} <span class="form-step-two__item-value--unit">HF</span></span>
-    </div>
+    <RedeemHoloFuelFormStepTwoItem :label="$t('redeem_holofuel.holo_fuel_amount')">
+      {{ props.amount }} <span class="form-step-two__item-value--unit">HF</span>
+    </RedeemHoloFuelFormStepTwoItem>
 
-    <div class="form-step-two__item">
-      <span class="form-step-two__item-label">{{ $t('redeem_holofuel.redemption_currency') }}</span>
-      <span class="form-step-two__item-value form-step-two__item-value--unit">HOT</span>
-    </div>
+    <RedeemHoloFuelFormStepTwoItem :label="$t('redeem_holofuel.redemption_currency')">
+      <span class="form-step-two__item-value--unit">HOT</span>
+    </RedeemHoloFuelFormStepTwoItem>
 
-    <div class="form-step-two__item">
-      <span class="form-step-two__item-label">{{ $t('redeem_holofuel.redemption_amount') }}</span>
-      <span class="form-step-two__item-value">{{ props.amount }} <span class="form-step-two__item-value--unit">HOT</span></span>
+    <RedeemHoloFuelFormStepTwoItem :label="$t('redeem_holofuel.redemption_amount')">
+      {{ props.amount }} <span class="form-step-two__item-value--unit">HOT</span>
+    </RedeemHoloFuelFormStepTwoItem>
+
+    <RedeemHoloFuelFormStepTwoItem :label="$t('redeem_holofuel.redemption_amount')">
+      1 <span class="form-step-two__item-value--unit">HF</span> = 1 <span class="form-step-two__item-value--unit">HOT</span>
+    </RedeemHoloFuelFormStepTwoItem>
+
+    <RedeemHoloFuelFormStepTwoItem :label="$t('redeem_holofuel.recipient_address_input_label')">
+      <span class="form-step-two__item-value--address">{{ props.hotAddress }}</span>
+    </RedeemHoloFuelFormStepTwoItem>
+
+    <div class="form-step-two__terms">
+      <input
+        id="partialRedemptionTermsAccepted"
+        :value="partialRedemptionTermsAccepted"
+        type="checkbox"
+        class="form-step-two__terms-checkbox"
+        @change="updatePartialRedemptionTermsAccepted"
+      />
+      <label
+        for="partialRedemptionTermsAccepted"
+        class="form-step-two__terms-label"
+      >
+        {{ $t('redeem_holofuel.partial_redemption_terms') }}
+      </label>
     </div>
   </div>
 </template>
@@ -56,19 +69,35 @@ watch(
     font-weight: 700;
   }
 
-  &__item {
+  &__item-value {
+    &--unit {
+      color: var(--grey-color);
+    }
+
+    &--address {
+      color: var(--grey-color);
+      font-weight: 400;
+    }
+  }
+
+  &__terms {
     display: flex;
-    flex-direction: column;
+    align-items: start;
     margin-top: 30px;
     font-size: 14px;
-    font-weight: 700;
+    font-weight: 600;
+    font-style: italic;
+    max-width: 620px;
     color: var(--grey-dark-color);
+    cursor: pointer;
 
-    &-value {
-      margin-top: 8px;
-      &--unit {
-        color: var(--grey-color);
-      }
+    &-checkbox:checked {
+      accent-color: var(--primary-light-color);
+    }
+
+    &-label {
+      margin-left: 10px;
+      cursor: pointer;
     }
   }
 }

--- a/src/components/earnings/RedeemHoloFuelFormStepTwo.vue
+++ b/src/components/earnings/RedeemHoloFuelFormStepTwo.vue
@@ -2,7 +2,7 @@
 import RedeemHoloFuelFormStepTwoItem from './RedeemHoloFuelFormStepTwoItem.vue'
 
 const props = defineProps<{
-  amount: number
+  amount: string
   hotAddress: string
   partialRedemptionTermsAccepted: boolean
 }>()

--- a/src/components/earnings/RedeemHoloFuelFormStepTwoItem.vue
+++ b/src/components/earnings/RedeemHoloFuelFormStepTwoItem.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+const props = defineProps<{
+  label: string
+}>()
+</script>
+
+<template>
+  <div class="form-step-two-item">
+    <span class="form-step-two-item__label">{{ props.label }}</span>
+    <span class="form-step-two-item__value"><slot /></span>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.form-step-two-item {
+  display: flex;
+  flex-direction: column;
+  margin-top: 30px;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--grey-dark-color);
+
+  &__value {
+    margin-top: 8px;
+    &--unit {
+      color: var(--grey-color);
+    }
+  }
+}
+</style>

--- a/src/components/earnings/RedeemableHoloFuelCard.vue
+++ b/src/components/earnings/RedeemableHoloFuelCard.vue
@@ -1,46 +1,8 @@
-<template>
-  <BaseCard
-    :is-loading="props.isLoading"
-    :is-error="props.isError"
-    class="redeemable-holofuel"
-    @try-again-clicked="emit('try-again-clicked')"
-  >
-    <CardHeader
-      :label="$t('earnings.redeemable_holofuel')"
-      :amount="props.data"
-      class="redeemable-holofuel__header"
-    />
-
-    <div class="redeemable-holofuel__links">
-      <BaseLinkButton
-        :to="kRoutes.redemptionHistory.path"
-        :icon="RedemptionHistoryIcon"
-        :label="$t('earnings.redemption_history')"
-        class="redeemable-holofuel__link"
-      />
-
-      <BaseLinkButton
-        is-disabled
-        to=""
-        :icon="RightArrowIcon"
-        :label="$t('earnings.redeem_holofuel')"
-        class="redeemable-holofuel__link"
-      />
-
-      <BaseLinkButton
-        to=""
-        :icon="TransferIcon"
-        :label="$t('earnings.transfer_holofuel')"
-        class="redeemable-holofuel__link"
-        @click="goToHoloFuel"
-      />
-    </div>
-  </BaseCard>
-</template>
-
 <script setup lang="ts">
 import BaseCard from '@uicommon/components/BaseCard.vue'
 import BaseLinkButton from '@uicommon/components/BaseLinkButton.vue'
+import { formatCurrency } from '@uicommon/utils/numbers'
+import { computed } from 'vue'
 import CardHeader from '@/components/earnings/CardHeader.vue'
 import RightArrowIcon from '@/components/icons/FatArrowIcon.vue'
 import RedemptionHistoryIcon from '@/components/icons/RedemptionHistoryIcon.vue'
@@ -57,7 +19,52 @@ const props = defineProps<{
   isLoading: boolean
   isError: boolean
 }>()
+
+const redeemableHoloFuel = computed((): number =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return
+  formatCurrency(Number(props.data) || 0)
+)
 </script>
+
+<template>
+  <BaseCard
+    :is-loading="props.isLoading"
+    :is-error="props.isError"
+    class="redeemable-holofuel"
+    @try-again-clicked="emit('try-again-clicked')"
+  >
+    <CardHeader
+      :label="$t('earnings.redeemable_holofuel')"
+      :amount="redeemableHoloFuel"
+      class="redeemable-holofuel__header"
+    />
+
+    <div class="redeemable-holofuel__links">
+      <BaseLinkButton
+        :to="kRoutes.redemptionHistory.path"
+        :icon="RedemptionHistoryIcon"
+        :label="$t('earnings.redemption_history')"
+        class="redeemable-holofuel__link"
+      />
+
+      <BaseLinkButton
+        :is-disabled="props.data === 0"
+        :to="kRoutes.redeemHoloFuel.path"
+        :icon="RightArrowIcon"
+        :label="$t('earnings.redeem_holofuel')"
+        class="redeemable-holofuel__link"
+      />
+
+      <BaseLinkButton
+        to=""
+        :icon="TransferIcon"
+        :label="$t('earnings.transfer_holofuel')"
+        class="redeemable-holofuel__link"
+        @click="goToHoloFuel"
+      />
+    </div>
+  </BaseCard>
+</template>
 
 <style lang="scss" scoped>
 .redeemable-holofuel {

--- a/src/interfaces/HposInterface.ts
+++ b/src/interfaces/HposInterface.ts
@@ -120,6 +120,7 @@ export interface HostEarnings {
   holofuel: {
     available: number | string
     balance: number | string
+    redeemable: number | string
   }
   recentPayments: unknown[]
 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -123,11 +123,13 @@ const translations = {
   redeem_holofuel: {
     available_to_redeem: 'available to redeem.',
     amount_input_label: 'Redemption Amount',
-    amount_input_placeholder: 'Enter HF amount, up to 18 decimals',
+    amount_input_placeholder: 'Enter HF amount',
     amount_input_error: 'Amount exceeds redeemable balance.',
     amount_input_tip: '*Note: HoloFuel and HOT are currently 1:1',
     confirm_and_redeem: 'Confirm & Redeem',
     holo_fuel_amount: 'HF Amount',
+    partial_redemption_terms:
+      'Redemptions are processed first come, first serve. By checking this box, you accept a partial redemption if 1) there isn’t enough HOT in the reserve to fulfill your entire request or 2) the price surpasses the minimum you have chosen.',
     recipient_address_input_label: 'Recipient HOT Address',
     recipient_address_input_placeholder: 'Enter HOT wallet address',
     recipient_address_input_error: 'HOT address not valid, please check it and try again.',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -18,6 +18,7 @@ const translations = {
       'This Identicon design and hash ID are both unique representations of this Host Console and associated HoloFuel address. Consider this address like a bank account, or crypto wallet. When you see this identicon, you know it’s your account.',
     learn_more: 'Learn more',
     logout: 'Logout',
+    next: 'Next',
     terms_of_service: 'Terms of Service',
     try_again: 'Try again'
   },
@@ -118,6 +119,24 @@ const translations = {
   recent_payments: {
     title: 'Recent Payments',
     no_payments: 'You have no payments'
+  },
+  redeem_holofuel: {
+    available_to_redeem: 'available to redeem.',
+    amount_input_label: 'Redemption Amount',
+    amount_input_placeholder: 'Enter HF amount, up to 18 decimals',
+    amount_input_error: 'Amount exceeds redeemable balance.',
+    amount_input_tip: '*Note: HoloFuel and HOT are currently 1:1',
+    confirm_and_redeem: 'Confirm & Redeem',
+    holo_fuel_amount: 'HF Amount',
+    recipient_address_input_label: 'Recipient HOT Address',
+    recipient_address_input_placeholder: 'Enter HOT wallet address',
+    recipient_address_input_error: 'HOT address not valid, please check it and try again.',
+    redemption_amount: 'Redemption Amount',
+    redemption_currency: 'Redemption Currency',
+    redemption_price: 'Redemption Price',
+    review_and_confirm: 'Please review and confirm:',
+    title: 'Redeem HoloFuel',
+    you_have: 'You have'
   },
   redemption_history: {
     errors: {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -6,6 +6,7 @@ const translations = {
   $: {
     ...commonTranslations.$,
     app_name: 'Host Console',
+    back: 'Back',
     dashboard: 'Dashboard',
     days: 'days',
     earnings: 'Earnings',

--- a/src/pages/EarningsPage.vue
+++ b/src/pages/EarningsPage.vue
@@ -1,3 +1,45 @@
+<script setup lang="ts">
+import { formatCurrency } from '@uicommon/utils/numbers'
+import { computed, onMounted, ref } from 'vue'
+import RedeemableHoloFuelCard from '@/components/earnings/RedeemableHoloFuelCard.vue'
+import WeeklyEarningsCard from '@/components/earnings/WeeklyEarningsCard.vue'
+import PrimaryLayout from '@/components/PrimaryLayout.vue'
+import { useDashboardStore } from '@/store/dashboard'
+import { isError as isErrorPredicate } from '@/types/predicates'
+
+const dashboardStore = useDashboardStore()
+
+const isLoading = ref(false)
+const isError = computed(() => !!dashboardStore.hostEarnings.error)
+
+const rawWeeklyEarnings = computed((): string | number =>
+  !isErrorPredicate(dashboardStore.hostEarnings)
+    ? dashboardStore.hostEarnings.earnings?.last7days
+    : 0
+)
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return
+const weeklyEarnings = computed((): number => formatCurrency(Number(rawWeeklyEarnings.value)) || 0)
+
+const redeemableHoloFuel = computed((): number =>
+  !isErrorPredicate(dashboardStore.hostEarnings)
+    ? Number(dashboardStore.hostEarnings.holofuel.redeemable)
+    : 0
+)
+
+async function getEarnings(): Promise<void> {
+  isLoading.value = true
+  await dashboardStore.getEarnings()
+  isLoading.value = false
+}
+
+onMounted(async (): Promise<void> => {
+  if (!rawWeeklyEarnings.value || !Number(rawWeeklyEarnings.value)) {
+    await getEarnings()
+  }
+})
+</script>
+
 <template>
   <PrimaryLayout
     :title="$t('$.earnings')"
@@ -23,44 +65,6 @@
     </div>
   </PrimaryLayout>
 </template>
-
-<script setup lang="ts">
-import { formatCurrency } from '@uicommon/utils/numbers'
-import { computed, onMounted, ref } from 'vue'
-import RedeemableHoloFuelCard from '@/components/earnings/RedeemableHoloFuelCard.vue'
-import WeeklyEarningsCard from '@/components/earnings/WeeklyEarningsCard.vue'
-import PrimaryLayout from '@/components/PrimaryLayout.vue'
-import { useDashboardStore } from '@/store/dashboard'
-import { isError as isErrorPredicate } from '@/types/predicates'
-
-const dashboardStore = useDashboardStore()
-
-const isLoading = ref(false)
-const isError = computed(() => !!dashboardStore.hostEarnings.error)
-
-const rawWeeklyEarnings = computed((): string | number =>
-  !isErrorPredicate(dashboardStore.hostEarnings)
-    ? dashboardStore.hostEarnings.earnings?.last7days
-    : 0
-)
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return
-const weeklyEarnings = computed((): number => formatCurrency(Number(rawWeeklyEarnings.value)) || 0)
-
-const redeemableHoloFuel = computed((): number => 0)
-
-async function getEarnings(): Promise<void> {
-  isLoading.value = true
-  await dashboardStore.getEarnings()
-  isLoading.value = false
-}
-
-onMounted(async (): Promise<void> => {
-  if (!weeklyEarnings.value) {
-    await getEarnings()
-  }
-})
-</script>
 
 <style lang="scss" scoped>
 .redeemable-holofuel-card {

--- a/src/pages/EarningsPage.vue
+++ b/src/pages/EarningsPage.vue
@@ -23,7 +23,7 @@ const weeklyEarnings = computed((): number => formatCurrency(Number(rawWeeklyEar
 
 const redeemableHoloFuel = computed((): number =>
   !isErrorPredicate(dashboardStore.hostEarnings)
-    ? Number(dashboardStore.hostEarnings.holofuel.redeemable)
+    ? Number(dashboardStore.hostEarnings.holofuel.redeemable || 0)
     : 0
 )
 

--- a/src/pages/RedeemHoloFuelPage.vue
+++ b/src/pages/RedeemHoloFuelPage.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import RedeemHoloFuelCard from '@/components/earnings/RedeemHoloFuelCard.vue'
+import PrimaryLayout from '@/components/PrimaryLayout.vue'
+import { useDashboardStore } from '@/store/dashboard'
+import { isError } from '@/types/predicates'
+import type { BreadCrumb } from '@/types/types'
+
+const { t } = useI18n()
+
+const isLoading = ref(false)
+
+const dashboardStore = useDashboardStore()
+
+const breadcrumbs = computed((): BreadCrumb[] => [
+  {
+    label: t('$.earnings'),
+    path: '/earnings'
+  },
+  {
+    label: t('earnings.redeem_holofuel')
+  }
+])
+
+async function getRedeemableHoloFuel(): Promise<void> {
+  isLoading.value = true
+  await dashboardStore.getEarnings()
+  isLoading.value = false
+}
+
+const redeemableHoloFuel = computed(() =>
+  isError(dashboardStore.hostEarnings)
+    ? dashboardStore.hostEarnings
+    : dashboardStore.hostEarnings.holofuel.redeemable
+)
+
+onMounted(async (): Promise<void> => {
+  await getRedeemableHoloFuel()
+})
+</script>
+
+<template>
+  <PrimaryLayout
+    title="earnings.redemption_history"
+    :breadcrumbs="breadcrumbs"
+  >
+    <RedeemHoloFuelCard
+      :is-loading="isLoading"
+      :data="redeemableHoloFuel"
+    />
+  </primarylayout>
+</template>

--- a/src/pages/RedeemHoloFuelPage.vue
+++ b/src/pages/RedeemHoloFuelPage.vue
@@ -29,11 +29,13 @@ async function getRedeemableHoloFuel(): Promise<void> {
   isLoading.value = false
 }
 
-const redeemableHoloFuel = computed(() =>
-  isError(dashboardStore.hostEarnings)
-    ? dashboardStore.hostEarnings
-    : dashboardStore.hostEarnings.holofuel.redeemable
-)
+const redeemableHoloFuel = computed(() => {
+  if (isError(dashboardStore.hostEarnings)) {
+    return dashboardStore.hostEarnings
+  }
+
+  return dashboardStore.hostEarnings.holofuel.redeemable || 0
+})
 
 onMounted(async (): Promise<void> => {
   await getRedeemableHoloFuel()
@@ -47,7 +49,7 @@ onMounted(async (): Promise<void> => {
   >
     <RedeemHoloFuelCard
       :is-loading="isLoading"
-      :data="redeemableHoloFuel"
+      :redeemable-holo-fuel="redeemableHoloFuel"
     />
   </primarylayout>
 </template>

--- a/src/pages/RedeemHoloFuelPage.vue
+++ b/src/pages/RedeemHoloFuelPage.vue
@@ -34,7 +34,7 @@ const redeemableHoloFuel = computed(() => {
     return dashboardStore.hostEarnings
   }
 
-  return dashboardStore.hostEarnings.holofuel.redeemable || 0
+  return dashboardStore.hostEarnings.holofuel.redeemable || '0'
 })
 
 onMounted(async (): Promise<void> => {

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,6 +7,7 @@ import HAppsPage from './pages/HAppsPage.vue'
 import HostingPreferences from './pages/HostingPreferences.vue'
 import InvoicesPage from './pages/InvoicesPage.vue'
 import LoginPage from './pages/LoginPage.vue'
+import RedeemHoloFuelPage from './pages/RedeemHoloFuelPage.vue'
 import RedemptionHistoryPage from './pages/RedemptionHistoryPage.vue'
 import SettingsPage from './pages/SettingsPage.vue'
 
@@ -21,6 +22,7 @@ interface Routes {
   unpaidInvoices: RouteRecordRaw
   hostingPreferences: RouteRecordRaw
   redemptionHistory: RouteRecordRaw
+  redeemHoloFuel: RouteRecordRaw
   default: RouteRecordRaw
 }
 
@@ -106,6 +108,15 @@ export const kRoutes: Routes = {
     }
   },
 
+  redeemHoloFuel: {
+    path: '/earnings/redeem-holofuel',
+    name: 'RedeemHoloFuel',
+    component: RedeemHoloFuelPage,
+    meta: {
+      requiresAuth: true
+    }
+  },
+
   hostingPreferences: {
     path: '/preferences',
     name: 'HostingPreferences',
@@ -135,6 +146,7 @@ export const routerFactory = (): Router => {
       kRoutes.hostingPreferences,
       kRoutes.paidInvoices,
       kRoutes.redemptionHistory,
+      kRoutes.redeemHoloFuel,
       kRoutes.unpaidInvoices,
       kRoutes.login
     ]


### PR DESCRIPTION
This PR:

- enables "Redeem HoloFuel" button when redeemable HF is above 0 HF on Dashboard -> HoloFuel card
<img width="398" alt="Screenshot 2023-04-25 at 14 25 54" src="https://user-images.githubusercontent.com/17565389/234275497-bee2f059-bd4f-4076-840b-11a074b240a1.png">

- enables "Redeem HoloFuel" button when redeemable HF is above 0 HF on Earnings Page
<img width="1201" alt="Screenshot 2023-04-25 at 14 26 57" src="https://user-images.githubusercontent.com/17565389/234275761-d3ba4287-f1c1-43f4-bd62-ba82aa1ab6cd.png">

- redirects to Redeem HoloFuel form when any of those buttons gets clicked

- adds Redeem HoloFuel Form with input validations
<img width="1467" alt="Screenshot 2023-04-25 at 14 27 41" src="https://user-images.githubusercontent.com/17565389/234275916-b9840882-6e50-45c5-acba-226a3b6d3f86.png">
 
<img width="1489" alt="Screenshot 2023-04-25 at 14 28 28" src="https://user-images.githubusercontent.com/17565389/234276091-dfc7f102-def7-4e56-bec2-67df6754a994.png">
<img width="1501" alt="Screenshot 2023-04-25 at 14 28 54" src="https://user-images.githubusercontent.com/17565389/234276205-480597cf-2f4d-4644-817a-2000a296f1d7.png">


