### PR TITLE
Feature/redeem-form: implement confirmation alert

### DIFF
--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -190,6 +190,40 @@ const getMyProfile = {
   }
 }
 
+const getAllReserveAccountsDetails = {
+  hash: 'QmYXJ5Y2FyZG9uLmNvbS9ob2xvZnVsb2c=',
+  pub_key: {
+    type: 'Buffer',
+    data: [
+      132, 32, 36, 157, 32, 140, 24, 241, 10, 28, 222, 179, 158, 62, 209, 80, 229, 227, 114, 241,
+      62, 210, 166, 100, 55, 151, 238, 176, 36, 80, 111, 82, 43, 225, 83, 139, 240, 203, 176
+    ]
+  },
+  info: {
+    external_reserve_currency: '',
+    external_account_number: '',
+    external_signing_key: '',
+    default_promise_expiry: '',
+    min_external_currency_tx_size: '',
+    max_external_currency_tx_size: '',
+    note: '',
+  }
+}
+
+const redemptionTransaction = {
+  id: 'dit7373ddjlg9204hfnfvu749506mvjshss7306mvjsd8',
+  amount: 1000000,
+  fee: 0,
+  completed_date: createDate(1, 1),
+  created_date: createDate(1, 1),
+  transaction_type: '',
+  counterparty: '',
+  direction: '',
+  status: '',
+  note: '',
+  proof_of_service: '',
+}
+
 const mockPaidInvoicesData = [
   {
     id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE6H',
@@ -526,6 +560,10 @@ const data = {
       switch (args.fnName) {
         case 'get_my_profile':
           return getMyProfile
+        case 'get_all_reserve_accounts_details':
+          return getAllReserveAccountsDetails
+        case 'redemption':
+          return redemptionTransaction
       }
     }
   }

--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -191,14 +191,8 @@ const getMyProfile = {
 }
 
 const getAllReserveAccountsDetails = {
-  hash: 'QmYXJ5Y2FyZG9uLmNvbS9ob2xvZnVsb2c=',
-  pub_key: {
-    type: 'Buffer',
-    data: [
-      132, 32, 36, 157, 32, 140, 24, 241, 10, 28, 222, 179, 158, 62, 209, 80, 229, 227, 114, 241,
-      62, 210, 166, 100, 55, 151, 238, 176, 36, 80, 111, 82, 43, 225, 83, 139, 240, 203, 176
-    ]
-  },
+  reserve_id: 'QmYXJ5Y2FyZG9uLmNvbS9ob2xvZnVsb2c=',
+  pub_key: 'uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp',
   info: {
     external_reserve_currency: '',
     external_account_number: '',
@@ -221,8 +215,9 @@ const redemptionTransaction = {
   direction: '',
   status: '',
   note: '',
-  proof_of_service: '',
-}
+  proof_of_service: {
+    redemption: '0x12345678...'
+  },}
 
 const mockPaidInvoicesData = [
   {
@@ -562,7 +557,7 @@ const data = {
           return getMyProfile
         case 'get_all_reserve_accounts_details':
           return getAllReserveAccountsDetails
-        case 'redemption':
+        case 'redeem':
           return redemptionTransaction
       }
     }

--- a/src/components/PrimaryLayout.vue
+++ b/src/components/PrimaryLayout.vue
@@ -1,59 +1,3 @@
-<template>
-  <section class="layout">
-    <TheSidebar />
-
-    <section
-      v-if="!isLoading"
-      class="main-column"
-    >
-      <MobileTopNav
-        :nickname="nickname"
-        :agent-address="agentAddress"
-      />
-
-      <TopNav
-        :breadcrumbs="breadcrumbsOrTitle"
-        :nickname="nickname"
-        :agent-address="agentAddress"
-      />
-
-      <WelcomeModal />
-
-      <GoToHoloFuelModal
-        :app-name="$t('$.app_name')"
-        :dont-show-modal-again-local-storage-key="kDontShowGoToHoloFuelModalAgainLSKey"
-        :holo-fuel-url="kHoloFuelUrl"
-      />
-
-      <section class="content">
-        <slot />
-
-        <div
-          v-if="props.isContentLoading || props.isContentError"
-          class="content__overlay"
-        >
-          <CircleSpinner
-            v-if="props.isContentLoading"
-            class="content__overlay-spinner"
-          />
-
-          <div
-            v-else-if="props.isContentError"
-            class="content__overlay-error-message"
-          >
-            <p>{{ $t('$.generic_error') }}</p>
-            <BaseButton
-              :type="EButtonType.gray"
-              :title="$t('$.try_again')"
-              @click="emit('try-again-clicked')"
-            />
-          </div>
-        </div>
-      </section>
-    </section>
-  </section>
-</template>
-
 <script setup lang="ts">
 import BaseButton from '@uicommon/components/BaseButton.vue'
 import CircleSpinner from '@uicommon/components/CircleSpinner.vue'
@@ -63,6 +7,7 @@ import { useOverlay } from '@uicommon/composables/useOverlay.js'
 import { EButtonType } from '@uicommon/types/ui.js'
 import { computed, nextTick, onMounted, ref } from 'vue'
 import MobileTopNav from '@/components/MobileTopNav.vue'
+import RedemptionInitiatedModal from '@/components/modals/RedemptionInitiatedModal.vue'
 import WelcomeModal from '@/components/modals/WelcomeModal.vue'
 import TheSidebar from '@/components/sidebar/TheSidebar.vue'
 import TopNav from '@/components/TopNav.vue'
@@ -144,6 +89,64 @@ onMounted(async () => {
   })
 })
 </script>
+
+<template>
+  <section class="layout">
+    <TheSidebar />
+
+    <section
+      v-if="!isLoading"
+      class="main-column"
+    >
+      <MobileTopNav
+        :nickname="nickname"
+        :agent-address="agentAddress"
+      />
+
+      <TopNav
+        :breadcrumbs="breadcrumbsOrTitle"
+        :nickname="nickname"
+        :agent-address="agentAddress"
+      />
+
+      <WelcomeModal />
+
+      <GoToHoloFuelModal
+        :app-name="$t('$.app_name')"
+        :dont-show-modal-again-local-storage-key="kDontShowGoToHoloFuelModalAgainLSKey"
+        :holo-fuel-url="kHoloFuelUrl"
+      />
+
+      <RedemptionInitiatedModal />
+
+      <section class="content">
+        <slot />
+
+        <div
+          v-if="props.isContentLoading || props.isContentError"
+          class="content__overlay"
+        >
+          <CircleSpinner
+            v-if="props.isContentLoading"
+            class="content__overlay-spinner"
+          />
+
+          <div
+            v-else-if="props.isContentError"
+            class="content__overlay-error-message"
+          >
+            <p>{{ $t('$.generic_error') }}</p>
+            <BaseButton
+              :type="EButtonType.gray"
+              :title="$t('$.try_again')"
+              @click="emit('try-again-clicked')"
+            />
+          </div>
+        </div>
+      </section>
+    </section>
+  </section>
+</template>
 
 <style lang="scss" scoped>
 .layout {

--- a/src/components/earnings/RedeemHoloFuelCard.vue
+++ b/src/components/earnings/RedeemHoloFuelCard.vue
@@ -49,7 +49,6 @@ async function handleSubmit(): Promise<void> {
   if (step.value === 1) {
     step.value = 2
   } else {
-    // TODO: submit form
     isLoading.value = true
 
     const transaction: RedemptionTransaction = await redeemHoloFuel({

--- a/src/components/earnings/RedeemHoloFuelCard.vue
+++ b/src/components/earnings/RedeemHoloFuelCard.vue
@@ -87,6 +87,7 @@ async function handleSubmit(): Promise<void> {
     } else {
       step.value = 1
       isBusy.value = false
+      partialRedemptionTermsAccepted.value = false
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call -- showBanner is coming from ui-common which is not using TS
       showBanner({ message: t('redemption.redeem_holofuel.errors.redemption_failed') })

--- a/src/components/earnings/RedeemHoloFuelCard.vue
+++ b/src/components/earnings/RedeemHoloFuelCard.vue
@@ -6,7 +6,7 @@ import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import RedeemHoloFuelFormStepOne from './RedeemHoloFuelFormStepOne.vue'
 import RedeemHoloFuelFormStepTwo from './RedeemHoloFuelFormStepTwo.vue'
-import {RedemptionTransaction, useHposInterface} from '@/interfaces/HposInterface'
+import { RedemptionTransaction, useHposInterface } from '@/interfaces/HposInterface'
 import { kRoutes } from '@/router'
 
 const { redeemHoloFuel } = useHposInterface()

--- a/src/components/earnings/RedeemHoloFuelFormStepOne.vue
+++ b/src/components/earnings/RedeemHoloFuelFormStepOne.vue
@@ -5,13 +5,15 @@ import { formatCurrency } from '@uicommon/utils/numbers'
 import { ref, computed, watch } from 'vue'
 
 const props = defineProps<{
-  redeemableAmount: number
+  redeemableAmount: string
+  amount: string
+  hotAddress: string
 }>()
 
 const emit = defineEmits(['update', 'update:is-valid'])
 
-const amount = ref('')
-const hotAddress = ref('')
+const amount = ref(`${props.amount}` || '')
+const hotAddress = ref(`${props.hotAddress}` || '')
 const hotAddressValidationIsActive = ref(false)
 
 const isAmountValid = computed(() => Number(amount.value) <= Number(props.redeemableAmount))
@@ -32,14 +34,12 @@ const formattedRedeemableHoloFuel = computed((): number =>
 )
 
 watch(
-  () => canSubmit.value,
-  (value) => {
-    emit('update:is-valid', value)
-
-    if (value) {
-      emit('update', { amount: amount.value, hotAddress: hotAddress.value })
-    }
-  }
+  () => [canSubmit.value, amount.value, hotAddress.value],
+  ([canSubmit, amount, hotAddress]) => {
+    emit('update:is-valid', canSubmit)
+    emit('update', { amount, hotAddress })
+  },
+  { immediate: true }
 )
 
 function activateHotAddressValidation(): void {

--- a/src/components/earnings/RedeemHoloFuelFormStepOne.vue
+++ b/src/components/earnings/RedeemHoloFuelFormStepOne.vue
@@ -51,9 +51,9 @@ function activateHotAddressValidation(): void {
 <template>
   <div>
     <div class="form-step-one__header">
-      <span>{{ $t('redeem_holofuel.you_have') }}</span>
+      <span>{{ $t('redemption.redeem_holofuel.you_have') }}</span>
       <span class="form-step-one__header-value">{{ formattedRedeemableHoloFuel }} HF</span>
-      <span>{{ $t('redeem_holofuel.available_to_redeem') }}</span>
+      <span>{{ $t('redemption.redeem_holofuel.available_to_redeem') }}</span>
     </div>
 
     <div class="form-step-one__input-wrapper">
@@ -62,13 +62,13 @@ function activateHotAddressValidation(): void {
         <BaseInput
           v-model="amount"
           autofocus
-          :label="$t('redeem_holofuel.amount_input_label')"
-          :placeholder="$t('redeem_holofuel.amount_input_placeholder')"
+          :label="$t('redemption.redeem_holofuel.amount_input_label')"
+          :placeholder="$t('redemption.redeem_holofuel.amount_input_placeholder')"
           :decimal-places="18"
           :is-valid="isAmountValid"
           has-errors
-          :message="isAmountValid ? '' : $t('redeem_holofuel.amount_input_error')"
-          :tip="$t('redeem_holofuel.amount_input_tip')"
+          :message="isAmountValid ? '' : $t('redemption.redeem_holofuel.amount_input_error')"
+          :tip="$t('redemption.redeem_holofuel.amount_input_tip')"
           name="amount"
           :input-type="EInputType.number"
           unit="HF"
@@ -83,9 +83,9 @@ function activateHotAddressValidation(): void {
           v-model="hotAddress"
           :is-valid="!hotAddressValidationIsActive || isHotAddressValid"
           has-errors
-          :message="!hotAddressValidationIsActive || isHotAddressValid ? '' : $t('redeem_holofuel.recipient_address_input_error')"
-          :label="$t('redeem_holofuel.recipient_address_input_label')"
-          :placeholder="$t('redeem_holofuel.recipient_address_input_placeholder')"
+          :message="!hotAddressValidationIsActive || isHotAddressValid ? '' : $t('redemption.redeem_holofuel.recipient_address_input_error')"
+          :label="$t('redemption.redeem_holofuel.recipient_address_input_label')"
+          :placeholder="$t('redemption.redeem_holofuel.recipient_address_input_placeholder')"
           name="amount"
           @blur="activateHotAddressValidation"
         />

--- a/src/components/earnings/RedeemHoloFuelFormStepTwo.vue
+++ b/src/components/earnings/RedeemHoloFuelFormStepTwo.vue
@@ -17,26 +17,26 @@ function updatePartialRedemptionTermsAccepted(event: Event): void {
 <template>
   <div>
     <div class="form-step-two__header">
-      <span>{{ $t('redeem_holofuel.review_and_confirm') }}</span>
+      <span>{{ $t('redemption.redeem_holofuel.review_and_confirm') }}</span>
     </div>
 
-    <RedeemHoloFuelFormStepTwoItem :label="$t('redeem_holofuel.holo_fuel_amount')">
+    <RedeemHoloFuelFormStepTwoItem :label="$t('redemption.redeem_holofuel.holo_fuel_amount')">
       {{ props.amount }} <span class="form-step-two__item-value--unit">HF</span>
     </RedeemHoloFuelFormStepTwoItem>
 
-    <RedeemHoloFuelFormStepTwoItem :label="$t('redeem_holofuel.redemption_currency')">
+    <RedeemHoloFuelFormStepTwoItem :label="$t('redemption.redeem_holofuel.redemption_currency')">
       <span class="form-step-two__item-value--unit">HOT</span>
     </RedeemHoloFuelFormStepTwoItem>
 
-    <RedeemHoloFuelFormStepTwoItem :label="$t('redeem_holofuel.redemption_amount')">
+    <RedeemHoloFuelFormStepTwoItem :label="$t('redemption.redeem_holofuel.redemption_amount')">
       {{ props.amount }} <span class="form-step-two__item-value--unit">HOT</span>
     </RedeemHoloFuelFormStepTwoItem>
 
-    <RedeemHoloFuelFormStepTwoItem :label="$t('redeem_holofuel.redemption_amount')">
+    <RedeemHoloFuelFormStepTwoItem :label="$t('redemption.redeem_holofuel.redemption_amount')">
       1 <span class="form-step-two__item-value--unit">HF</span> = 1 <span class="form-step-two__item-value--unit">HOT</span>
     </RedeemHoloFuelFormStepTwoItem>
 
-    <RedeemHoloFuelFormStepTwoItem :label="$t('redeem_holofuel.recipient_address_input_label')">
+    <RedeemHoloFuelFormStepTwoItem :label="$t('redemption.redeem_holofuel.recipient_address_input_label')">
       <span class="form-step-two__item-value--address">{{ props.hotAddress }}</span>
     </RedeemHoloFuelFormStepTwoItem>
 
@@ -52,7 +52,7 @@ function updatePartialRedemptionTermsAccepted(event: Event): void {
         for="partialRedemptionTermsAccepted"
         class="form-step-two__terms-label"
       >
-        {{ $t('redeem_holofuel.partial_redemption_terms') }}
+        {{ $t('redemption.redeem_holofuel.partial_redemption_terms') }}
       </label>
     </div>
   </div>

--- a/src/components/earnings/RedeemHoloFuelFormStepTwo.vue
+++ b/src/components/earnings/RedeemHoloFuelFormStepTwo.vue
@@ -2,7 +2,7 @@
 import RedeemHoloFuelFormStepTwoItem from './RedeemHoloFuelFormStepTwoItem.vue'
 
 const props = defineProps<{
-  amount: number
+  amount: string
   hotAddress: string
   partialRedemptionTermsAccepted: boolean
 }>()

--- a/src/components/earnings/RedemptionHistoryTableRow.vue
+++ b/src/components/earnings/RedemptionHistoryTableRow.vue
@@ -61,7 +61,7 @@ function showTransactionPrice(state: boolean): void {
               v-if="isPartialInfoVisible"
               class="redemption-history-table-row__info-popover redemption-history-table-row__partial-info-popover"
             >
-              {{ $t('redemption_history.original_requested_amount', { amount: props.redemption.formattedRequestedAmount }) }}
+              {{ $t('redemption.history.original_requested_amount', { amount: props.redemption.formattedRequestedAmount }) }}
             </div>
           </Transition>
         </div>
@@ -90,7 +90,7 @@ function showTransactionPrice(state: boolean): void {
             v-if="isPriceVisible"
             class="redemption-history-table-row__info-popover redemption-history-table-row__price-info-popover"
           >
-            {{ $t('redemption_history.transaction_price', { hf: 1, hot: 1 }) }}
+            {{ $t('redemption.transaction_price', { hf: 1, hot: 1 }) }}
           </div>
         </Transition>
       </div>

--- a/src/components/modals/RedemptionInitiatedModal.vue
+++ b/src/components/modals/RedemptionInitiatedModal.vue
@@ -1,0 +1,219 @@
+<script setup lang="ts">
+import { CheckCircleIcon } from '@heroicons/vue/24/outline'
+import BaseButton from '@uicommon/components/BaseButton.vue'
+import BaseModal from '@uicommon/components/BaseModal.vue'
+import { useModals } from '@uicommon/composables/useModals'
+import { formatCurrency } from '@uicommon/utils/numbers'
+import { useElementHover } from '@vueuse/core'
+import dayjs from 'dayjs'
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import RedemptionInitiatedModalItem from './RedemptionInitiatedModalItem.vue'
+import { EModal, kDefaultDateTimeFormat, kMsInSecond } from '@/constants/ui'
+
+const { t } = useI18n()
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
+const { visibleModal, hideModal, modalProps } = useModals()
+
+const isPriceVisible = ref(false)
+
+const formattedRedemptionAmount = computed((): number | string => {
+  const rawRedemptionAmount: string = modalProps.value.redemptionAmount
+  return rawRedemptionAmount && Number(rawRedemptionAmount)
+    ? formatCurrency(Number(rawRedemptionAmount))
+    : 0
+})
+
+const formattedHfAmount = computed((): number | string => {
+  const rawHfAmount: string = modalProps.value.hfAmount
+  return rawHfAmount && Number(rawHfAmount) ? formatCurrency(Number(rawHfAmount)) : 0
+})
+
+const formattedDate = computed((): string =>
+  dayjs(new Date(modalProps.value.date / kMsInSecond)).format(kDefaultDateTimeFormat)
+)
+
+function showTransactionPrice(state: boolean): void {
+  if (formattedRedemptionAmount.value !== '---') {
+    isPriceVisible.value = state
+  }
+}
+
+// Hover effect
+const el = ref()
+const isHovered = useElementHover(el, { delayEnter: 300, delayLeave: 0 })
+
+watch(isHovered, (value) => {
+  showTransactionPrice(value)
+})
+
+interface Item {
+  label: string
+  value: string
+  tipMessage?: string
+}
+
+const items = computed((): Item[] => [
+  {
+    label: `${t('redeem_holofuel.request_id')}:`,
+    value: modalProps.value.requestId
+  },
+  {
+    label: `${t('$.date')}:`,
+    value: formattedDate.value
+  },
+  {
+    label: `${t('redeem_holofuel.holo_fuel_amount')}:`,
+    value: `${formattedHfAmount.value} HF`
+  },
+  {
+    label: `${t('redeem_holofuel.redemption_currency')}:`,
+    value: modalProps.value.currency
+  },
+  {
+    label: `${t('redeem_holofuel.redemption_amount')}:`,
+    value: `${formattedRedemptionAmount.value} HOT`,
+    tipMessage: t('redemption_history.transaction_price', { hf: 1, hot: 1 })
+  },
+  {
+    label: `${t('redeem_holofuel.recipient_address_input_label')}:`,
+    value: modalProps.value.hotAddress
+  }
+])
+</script>
+
+<template>
+  <BaseModal
+    :is-visible="visibleModal === EModal.redemption_initiated"
+    @close="hideModal"
+  >
+    <div class="redemption-initiated-modal">
+      <div	class="redemption-initiated-modal__header">
+        <CheckCircleIcon class="redemption-initiated-modal__header-icon" />
+
+        <p class="redemption-initiated-modal__header-label">
+          {{ $t('redeem_holofuel.redemption_initiated') }}
+        </p>
+      </div>
+
+      <div class="redemption-initiated-modal__description">
+        <RedemptionInitiatedModalItem
+          v-for="item in items"
+          :key="item.label"
+          :label="item.label"
+          :value="item.value"
+          :tip-message="item.tipMessage || ''"
+        />
+      </div>
+    </div>
+
+    <template #buttons>
+      <BaseButton
+        class="redemption-initiated-modal__button"
+        @click="hideModal"
+      >
+        {{ $t('$.close') }}
+      </BaseButton>
+    </template>
+  </BaseModal>
+</template>
+
+<style scoped lang="scss">
+.redemption-initiated-modal {
+  &__header {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    &-icon {
+      height: 78px;
+      color: var(--primary-color);
+    }
+
+    &-label {
+      margin-top: 20px;
+      font-size: 22px;
+      font-weight: 700;
+      line-height: 29px;
+      color: var(--grey-dark-color);
+    }
+  }
+
+  &__description {
+    display: flex;
+    flex-direction: column;
+    margin-top: 40px;
+
+    &-item {
+      display: grid;
+      grid-template-columns: 170px 1fr;
+      text-align: start;
+      margin-top: 16px;
+
+      &-label {
+        font-weight: 800;
+        color: var(--grey-dark-color);
+      }
+
+      &-value {
+        font-weight: 600;
+        color: var(--grey-color);
+        position: relative;
+      }
+    }
+  }
+
+  &__button {
+    margin-top: 24px;
+  }
+
+  &__info-popover {
+    position: absolute;
+    top: 25px;
+    left: 0px;
+    width: 100px;
+    z-index: 50;
+    background: var(--white-color);
+    border-radius: 2px;
+    font-size: 12px;
+    line-height: 19px;
+    color: var(--grey-color);
+    margin-top: 1px;
+    padding: 8px;
+    cursor: pointer;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+
+    &:before {
+      position: absolute;
+      left: 7px;
+      top: -5px;
+      content: '';
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-width: 0 6px 6px 6px;
+      border-color: transparent transparent white transparent;
+    }
+  }
+
+  @media screen and (max-width: 1050px) {
+    &__description-item {
+      display: grid;
+      grid-template-columns: 170px;
+      text-align: start;
+      margin-top: 16px;
+    }
+  }
+}
+
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 150ms ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/components/modals/RedemptionInitiatedModal.vue
+++ b/src/components/modals/RedemptionInitiatedModal.vue
@@ -7,6 +7,7 @@ import { formatCurrency } from '@uicommon/utils/numbers'
 import { useElementHover } from '@vueuse/core'
 import dayjs from 'dayjs'
 import { computed, ref, watch } from 'vue'
+import type { Ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import RedemptionInitiatedModalItem from './RedemptionInitiatedModalItem.vue'
 import { EModal, kDefaultDateTimeFormat, kMsInSecond } from '@/constants/ui'
@@ -18,20 +19,28 @@ const { visibleModal, hideModal, modalProps } = useModals()
 
 const isPriceVisible = ref(false)
 
-const formattedRedemptionAmount = computed((): number | string => {
-  const rawRedemptionAmount: string = modalProps.value.redemptionAmount
-  return rawRedemptionAmount && Number(rawRedemptionAmount)
-    ? formatCurrency(Number(rawRedemptionAmount))
-    : 0
-})
+interface Props {
+  requestId: string
+  date: string
+  hfAmount: string
+  currency: string
+  redemptionAmount: string
+  hotAddress: string
+}
 
-const formattedHfAmount = computed((): number | string => {
-  const rawHfAmount: string = modalProps.value.hfAmount
-  return rawHfAmount && Number(rawHfAmount) ? formatCurrency(Number(rawHfAmount)) : 0
-})
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const props = modalProps as Ref<Props>
+
+const formattedRedemptionAmount = computed((): string =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return
+  formatCurrency(Number(props.value.redemptionAmount))
+)
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return
+const formattedHfAmount = computed((): string => formatCurrency(Number(props.value.hfAmount)))
 
 const formattedDate = computed((): string =>
-  dayjs(new Date(modalProps.value.date / kMsInSecond)).format(kDefaultDateTimeFormat)
+  dayjs(new Date(props.value.date / kMsInSecond)).format(kDefaultDateTimeFormat)
 )
 
 function showTransactionPrice(state: boolean): void {
@@ -56,29 +65,29 @@ interface Item {
 
 const items = computed((): Item[] => [
   {
-    label: `${t('redeem_holofuel.request_id')}:`,
-    value: modalProps.value.requestId
+    label: `${t('redemption.redeem_holofuel.request_id')}:`,
+    value: props.value.requestId
   },
   {
     label: `${t('$.date')}:`,
     value: formattedDate.value
   },
   {
-    label: `${t('redeem_holofuel.holo_fuel_amount')}:`,
+    label: `${t('redemption.redeem_holofuel.holo_fuel_amount')}:`,
     value: `${formattedHfAmount.value} HF`
   },
   {
-    label: `${t('redeem_holofuel.redemption_currency')}:`,
-    value: modalProps.value.currency
+    label: `${t('redemption.redeem_holofuel.redemption_currency')}:`,
+    value: props.value.currency
   },
   {
-    label: `${t('redeem_holofuel.redemption_amount')}:`,
+    label: `${t('redemption.redeem_holofuel.redemption_amount')}:`,
     value: `${formattedRedemptionAmount.value} HOT`,
-    tipMessage: t('redemption_history.transaction_price', { hf: 1, hot: 1 })
+    tipMessage: t('redemption.redeem_holofuel.transaction_price', { hf: 1, hot: 1 })
   },
   {
-    label: `${t('redeem_holofuel.recipient_address_input_label')}:`,
-    value: modalProps.value.hotAddress
+    label: `${t('redemption.redeem_holofuel.recipient_address_input_label')}:`,
+    value: props.value.hotAddress
   }
 ])
 </script>
@@ -93,7 +102,7 @@ const items = computed((): Item[] => [
         <CheckCircleIcon class="redemption-initiated-modal__header-icon" />
 
         <p class="redemption-initiated-modal__header-label">
-          {{ $t('redeem_holofuel.redemption_initiated') }}
+          {{ t('redemption.redeem_holofuel.redemption_initiated') }}
         </p>
       </div>
 

--- a/src/components/modals/RedemptionInitiatedModal.vue
+++ b/src/components/modals/RedemptionInitiatedModal.vue
@@ -144,76 +144,10 @@ const items = computed((): Item[] => [
     display: flex;
     flex-direction: column;
     margin-top: 40px;
-
-    &-item {
-      display: grid;
-      grid-template-columns: 170px 1fr;
-      text-align: start;
-      margin-top: 16px;
-
-      &-label {
-        font-weight: 800;
-        color: var(--grey-dark-color);
-      }
-
-      &-value {
-        font-weight: 600;
-        color: var(--grey-color);
-        position: relative;
-      }
-    }
   }
 
   &__button {
     margin-top: 24px;
   }
-
-  &__info-popover {
-    position: absolute;
-    top: 25px;
-    left: 0px;
-    width: 100px;
-    z-index: 50;
-    background: var(--white-color);
-    border-radius: 2px;
-    font-size: 12px;
-    line-height: 19px;
-    color: var(--grey-color);
-    margin-top: 1px;
-    padding: 8px;
-    cursor: pointer;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
-
-    &:before {
-      position: absolute;
-      left: 7px;
-      top: -5px;
-      content: '';
-      width: 0;
-      height: 0;
-      border-style: solid;
-      border-width: 0 6px 6px 6px;
-      border-color: transparent transparent white transparent;
-    }
-  }
-
-  @media screen and (max-width: 1050px) {
-    &__description-item {
-      display: grid;
-      grid-template-columns: 170px;
-      text-align: start;
-      margin-top: 16px;
-    }
-  }
-}
-
-.v-enter-active,
-.v-leave-active {
-  transition: opacity 150ms ease;
-}
-
-.v-enter-from,
-.v-leave-to {
-  opacity: 0;
 }
 </style>

--- a/src/components/modals/RedemptionInitiatedModalItem.vue
+++ b/src/components/modals/RedemptionInitiatedModalItem.vue
@@ -97,14 +97,14 @@ watch(isHovered, (value) => {
       border-color: transparent transparent white transparent;
     }
   }
+}
 
-  @media screen and (max-width: 1050px) {
-    &__description-item {
-      display: grid;
-      grid-template-columns: 170px;
-      text-align: start;
-      margin-top: 16px;
-    }
+@media screen and (max-width: 1050px) {
+  .description-item {
+    display: grid;
+    grid-template-columns: 170px;
+    text-align: start;
+    margin-top: 16px;
   }
 }
 

--- a/src/components/modals/RedemptionInitiatedModalItem.vue
+++ b/src/components/modals/RedemptionInitiatedModalItem.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import { useElementHover } from '@vueuse/core'
+import { ref, watch } from 'vue'
+
+const props = withDefaults(
+  defineProps<{
+    tipMessage?: string
+    label: string
+    value: string
+  }>(),
+  {
+    hasTip: false,
+    tipMessage: ''
+  }
+)
+
+const isTipVisible = ref(false)
+
+function showTip(state: boolean): void {
+  if (props.tipMessage && props.value !== '---') {
+    isTipVisible.value = state
+  }
+}
+
+// Hover effect
+const el = ref()
+const isHovered = useElementHover(el, { delayEnter: 300, delayLeave: 0 })
+
+watch(isHovered, (value) => {
+  showTip(value)
+})
+</script>
+
+<template>
+  <div class="description-item">
+    <span class="description-item__label">{{ props.label }}</span>
+    <span
+      ref="el"
+      class="description-item__value"
+    >
+      <Transition>
+        <div
+          v-if="isTipVisible"
+          class="description-item__info-popover"
+        >
+          {{ props.tipMessage }}
+        </div>
+      </Transition>
+      {{ props.value }}
+    </span>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.description-item {
+  display: grid;
+  grid-template-columns: 170px 1fr;
+  text-align: start;
+  margin-top: 16px;
+
+  &__label {
+    font-weight: 800;
+    color: var(--grey-dark-color);
+  }
+
+  &__value {
+    font-weight: 600;
+    color: var(--grey-color);
+    position: relative;
+  }
+
+  &__info-popover {
+    position: absolute;
+    top: 25px;
+    left: 0px;
+    width: 100px;
+    z-index: 50;
+    background: var(--white-color);
+    border-radius: 2px;
+    font-size: 12px;
+    line-height: 19px;
+    color: var(--grey-color);
+    margin-top: 1px;
+    padding: 8px;
+    cursor: pointer;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+
+    &:before {
+      position: absolute;
+      left: 7px;
+      top: -5px;
+      content: '';
+      width: 0;
+      height: 0;
+      border-style: solid;
+      border-width: 0 6px 6px 6px;
+      border-color: transparent transparent white transparent;
+    }
+  }
+
+  @media screen and (max-width: 1050px) {
+    &__description-item {
+      display: grid;
+      grid-template-columns: 170px;
+      text-align: start;
+      margin-top: 16px;
+    }
+  }
+}
+
+.v-enter-active,
+.v-leave-active {
+  transition: opacity 150ms ease;
+}
+
+.v-enter-from,
+.v-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/components/sidebar/TheSidebar.vue
+++ b/src/components/sidebar/TheSidebar.vue
@@ -90,7 +90,7 @@ const items = computed((): SidebarItem[] => [
   flex: 0 0 270px;
   background: var(--white-color);
   box-shadow: 0 4px 4px rgba(54, 59, 71, 0.1);
-  z-index: 100;
+  z-index: 20;
 
   &__header {
     background-color: rgba(0, 202, 217, 0.06);

--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -9,6 +9,10 @@ export const kSortOptions = {
   }
 }
 
-export const EModal = {
-  welcome: 100
+export enum EModal {
+  welcome,
+  redemption_initiated
 }
+
+export const kMsInSecond = 1000
+export const kDefaultDateTimeFormat = 'DD MMM YYYY hh:mm UTC'

--- a/src/interfaces/HposInterface.ts
+++ b/src/interfaces/HposInterface.ts
@@ -29,7 +29,7 @@ interface HposInterface {
 
 interface RedeemHoloFuelPayload {
   amount: string
-  note: string
+  note?: string
   wallet_address: string
 }
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -128,6 +128,9 @@ const translations = {
     amount_input_error: 'Amount exceeds redeemable balance.',
     amount_input_tip: '*Note: HoloFuel and HOT are currently 1:1',
     confirm_and_redeem: 'Confirm & Redeem',
+    errors: {
+      redemption_failed: 'Something went wrong, please try again.'
+    },
     holo_fuel_amount: 'HF Amount',
     partial_redemption_terms:
       'Redemptions are processed first come, first serve. By checking this box, you accept a partial redemption if 1) there isn’t enough HOT in the reserve to fulfill your entire request or 2) the price surpasses the minimum you have chosen.',

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -8,6 +8,7 @@ const translations = {
     app_name: 'Host Console',
     back: 'Back',
     dashboard: 'Dashboard',
+    date: 'Date',
     days: 'days',
     earnings: 'Earnings',
     generic_error: 'Sorry, we couldn’t fetch this data.',
@@ -135,7 +136,9 @@ const translations = {
     recipient_address_input_error: 'HOT address not valid, please check it and try again.',
     redemption_amount: 'Redemption Amount',
     redemption_currency: 'Redemption Currency',
+    redemption_initiated: 'Redemption Initiated!',
     redemption_price: 'Redemption Price',
+    request_id: 'Request ID',
     review_and_confirm: 'Please review and confirm:',
     title: 'Redeem HoloFuel',
     you_have: 'You have'

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -121,44 +121,46 @@ const translations = {
     title: 'Recent Payments',
     no_payments: 'You have no payments'
   },
-  redeem_holofuel: {
-    available_to_redeem: 'available to redeem.',
-    amount_input_label: 'Redemption Amount',
-    amount_input_placeholder: 'Enter HF amount',
-    amount_input_error: 'Amount exceeds redeemable balance.',
-    amount_input_tip: '*Note: HoloFuel and HOT are currently 1:1',
-    confirm_and_redeem: 'Confirm & Redeem',
-    errors: {
-      redemption_failed: 'Something went wrong, please try again.'
+  redemption: {
+    transaction_price: 'Transaction Price: {hf} HF = {hot} HOT',
+    history: {
+      errors: {
+        no_redemptions: 'You have no redemptions.'
+      },
+      headers: {
+        created: 'Date Submitted',
+        hf_amount: 'HF Amount',
+        redemption_amount: 'Redemption Amount',
+        transaction_id: 'Transaction ID',
+        status: 'Status'
+      },
+      original_requested_amount: 'Original Requested Amount: {amount}'
     },
-    holo_fuel_amount: 'HF Amount',
-    partial_redemption_terms:
-      'Redemptions are processed first come, first serve. By checking this box, you accept a partial redemption if 1) there isn’t enough HOT in the reserve to fulfill your entire request or 2) the price surpasses the minimum you have chosen.',
-    recipient_address_input_label: 'Recipient HOT Address',
-    recipient_address_input_placeholder: 'Enter HOT wallet address',
-    recipient_address_input_error: 'HOT address not valid, please check it and try again.',
-    redemption_amount: 'Redemption Amount',
-    redemption_currency: 'Redemption Currency',
-    redemption_initiated: 'Redemption Initiated!',
-    redemption_price: 'Redemption Price',
-    request_id: 'Request ID',
-    review_and_confirm: 'Please review and confirm:',
-    title: 'Redeem HoloFuel',
-    you_have: 'You have'
-  },
-  redemption_history: {
-    errors: {
-      no_redemptions: 'You have no redemptions.'
-    },
-    headers: {
-      created: 'Date Submitted',
-      hf_amount: 'HF Amount',
+    redeem_holofuel: {
+      available_to_redeem: 'available to redeem.',
+      amount_input_label: 'Redemption Amount',
+      amount_input_placeholder: 'Enter HF amount',
+      amount_input_error: 'Amount exceeds redeemable balance.',
+      amount_input_tip: '*Note: HoloFuel and HOT are currently 1:1',
+      confirm_and_redeem: 'Confirm & Redeem',
+      errors: {
+        redemption_failed: 'Something went wrong, please try again.'
+      },
+      holo_fuel_amount: 'HF Amount',
+      partial_redemption_terms:
+        'Redemptions are processed first come, first serve. By checking this box, you accept a partial redemption if 1) there isn’t enough HOT in the reserve to fulfill your entire request or 2) the price surpasses the minimum you have chosen.',
+      recipient_address_input_label: 'Recipient HOT Address',
+      recipient_address_input_placeholder: 'Enter HOT wallet address',
+      recipient_address_input_error: 'HOT address not valid, please check it and try again.',
       redemption_amount: 'Redemption Amount',
-      transaction_id: 'Transaction ID',
-      status: 'Status'
-    },
-    original_requested_amount: 'Original Requested Amount: {amount}',
-    transaction_price: 'Transaction Price: {hf} HF = {hot} HOT'
+      redemption_currency: 'Redemption Currency',
+      redemption_initiated: 'Redemption Initiated!',
+      redemption_price: 'Redemption Price',
+      request_id: 'Request ID',
+      review_and_confirm: 'Please review and confirm:',
+      title: 'Redeem HoloFuel',
+      you_have: 'You have'
+    }
   },
   settings: {
     account_display_name: 'Account Display Name',

--- a/src/pages/DashboardPage.vue
+++ b/src/pages/DashboardPage.vue
@@ -1,59 +1,3 @@
-<template>
-  <PrimaryLayout
-    :title="$t('$.dashboard')"
-    data-test-dashboard-layout
-  >
-    <div class="row">
-      <UsageCard
-        :is-loading="isLoadingUsage"
-        :data="usage"
-        data-test-dashboard-usage-card
-        @try-again-clicked="getUsage"
-      />
-
-      <HoloFuelCard
-        :is-loading="isLoadingEarnings"
-        :data="holoFuel"
-        class="holofuel-card"
-        data-test-dashboard-holo-fuel-card
-        @try-again-clicked="getEarnings"
-      />
-    </div>
-
-    <div class="row">
-      <HappsCard
-        :data="topHostedHapps"
-        :is-loading="isLoadingHostedHapps"
-        with-more-button
-        class="happs-card"
-        data-test-dashboard-happs-card
-        @more-clicked="() => router.push({ name: kRoutes.happs.name })"
-        @try-again-clicked="getTopHostedHapps"
-      />
-
-      <EarningsCard
-        :data="earnings"
-        :is-loading="isLoadingEarnings"
-        with-more-button
-        class="earnings-card"
-        data-test-dashboard-earnings-card
-        @more-clicked="() => router.push({ name: kRoutes.earnings.name })"
-        @try-again-clicked="getEarnings"
-      />
-
-      <RecentPaymentsCard
-        :data="recentPayments"
-        :is-loading="isLoadingEarnings"
-        with-more-button
-        class="payments-card"
-        data-test-dashboard-payments-card
-        @more-clicked="() => router.push({ name: kRoutes.paidInvoices.name })"
-        @try-again-clicked="getEarnings"
-      />
-    </div>
-  </PrimaryLayout>
-</template>
-
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
@@ -126,6 +70,62 @@ onMounted(async (): Promise<void> => {
   await getTopHostedHapps()
 })
 </script>
+
+<template>
+  <PrimaryLayout
+    :title="$t('$.dashboard')"
+    data-test-dashboard-layout
+  >
+    <div class="row">
+      <UsageCard
+        :is-loading="isLoadingUsage"
+        :data="usage"
+        data-test-dashboard-usage-card
+        @try-again-clicked="getUsage"
+      />
+
+      <HoloFuelCard
+        :is-loading="isLoadingEarnings"
+        :data="holoFuel"
+        class="holofuel-card"
+        data-test-dashboard-holo-fuel-card
+        @try-again-clicked="getEarnings"
+      />
+    </div>
+
+    <div class="row">
+      <HappsCard
+        :data="topHostedHapps"
+        :is-loading="isLoadingHostedHapps"
+        with-more-button
+        class="happs-card"
+        data-test-dashboard-happs-card
+        @more-clicked="() => router.push({ name: kRoutes.happs.name })"
+        @try-again-clicked="getTopHostedHapps"
+      />
+
+      <EarningsCard
+        :data="earnings"
+        :is-loading="isLoadingEarnings"
+        with-more-button
+        class="earnings-card"
+        data-test-dashboard-earnings-card
+        @more-clicked="() => router.push({ name: kRoutes.earnings.name })"
+        @try-again-clicked="getEarnings"
+      />
+
+      <RecentPaymentsCard
+        :data="recentPayments"
+        :is-loading="isLoadingEarnings"
+        with-more-button
+        class="payments-card"
+        data-test-dashboard-payments-card
+        @more-clicked="() => router.push({ name: kRoutes.paidInvoices.name })"
+        @try-again-clicked="getEarnings"
+      />
+    </div>
+  </PrimaryLayout>
+</template>
 
 <style scoped>
 .row {

--- a/src/pages/RedeemHoloFuelPage.vue
+++ b/src/pages/RedeemHoloFuelPage.vue
@@ -8,7 +8,6 @@ import { EModal } from '@/constants/ui'
 import type { RedemptionTransaction } from '@/interfaces/HposInterface'
 import router, { kRoutes } from '@/router'
 import { useDashboardStore } from '@/store/dashboard'
-import { isError } from '@/types/predicates'
 import type { BreadCrumb } from '@/types/types'
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
@@ -55,14 +54,6 @@ async function handleRedemptionSubmitted(
   })
 }
 
-const redeemableHoloFuel = computed(() => {
-  if (isError(dashboardStore.hostEarnings)) {
-    return dashboardStore.hostEarnings
-  }
-
-  return dashboardStore.hostEarnings.holofuel.redeemable || '0'
-})
-
 onMounted(async (): Promise<void> => {
   await getRedeemableHoloFuel()
 })
@@ -75,7 +66,6 @@ onMounted(async (): Promise<void> => {
   >
     <RedeemHoloFuelCard
       :is-loading="isLoading"
-      :redeemable-holo-fuel="redeemableHoloFuel"
       @submitted="handleRedemptionSubmitted"
     />
   </primarylayout>

--- a/src/pages/RedeemHoloFuelPage.vue
+++ b/src/pages/RedeemHoloFuelPage.vue
@@ -1,16 +1,22 @@
 <script setup lang="ts">
+import { useModals } from '@uicommon/composables/useModals'
 import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import RedeemHoloFuelCard from '@/components/earnings/RedeemHoloFuelCard.vue'
 import PrimaryLayout from '@/components/PrimaryLayout.vue'
+import { EModal } from '@/constants/ui'
+import type { RedemptionTransaction } from '@/interfaces/HposInterface'
+import router, { kRoutes } from '@/router'
 import { useDashboardStore } from '@/store/dashboard'
 import { isError } from '@/types/predicates'
 import type { BreadCrumb } from '@/types/types'
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
+const { showModal } = useModals()
+
 const { t } = useI18n()
 
 const isLoading = ref(false)
-
 const dashboardStore = useDashboardStore()
 
 const breadcrumbs = computed((): BreadCrumb[] => [
@@ -27,6 +33,26 @@ async function getRedeemableHoloFuel(): Promise<void> {
   isLoading.value = true
   await dashboardStore.getEarnings()
   isLoading.value = false
+}
+
+interface ExtendedRedemptionTransaction extends RedemptionTransaction {
+  hotAddress: string
+}
+
+async function handleRedemptionSubmitted(
+  transaction: ExtendedRedemptionTransaction
+): Promise<void> {
+  await router.push({ name: kRoutes.earnings.name })
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-return
+  showModal(EModal.redemption_initiated, {
+    date: transaction.created_date,
+    hfAmount: transaction.amount,
+    requestId: transaction.id,
+    currency: 'HOT',
+    hotAddress: transaction.hotAddress,
+    redemptionAmount: transaction.amount
+  })
 }
 
 const redeemableHoloFuel = computed(() => {
@@ -50,6 +76,7 @@ onMounted(async (): Promise<void> => {
     <RedeemHoloFuelCard
       :is-loading="isLoading"
       :redeemable-holo-fuel="redeemableHoloFuel"
+      @submitted="handleRedemptionSubmitted"
     />
   </primarylayout>
 </template>

--- a/src/pages/RedeemHoloFuelPage.vue
+++ b/src/pages/RedeemHoloFuelPage.vue
@@ -48,6 +48,7 @@ async function handleRedemptionSubmitted(
     date: transaction.created_date,
     hfAmount: transaction.amount,
     requestId: transaction.id,
+    // Hardcoded until we add the call to support other Reserve types, will be dynamic in the future
     currency: 'HOT',
     hotAddress: transaction.hotAddress,
     redemptionAmount: transaction.amount

--- a/src/pages/RedemptionHistoryPage.vue
+++ b/src/pages/RedemptionHistoryPage.vue
@@ -73,7 +73,7 @@ const headersMap = computed(
         'createdDate',
         {
           key: 'createdDate',
-          label: t('redemption_history.headers.created'),
+          label: t('redemption.history.headers.created'),
           isVisibleOnMobile: true,
           isSortable: true,
           type: 'date'
@@ -83,7 +83,7 @@ const headersMap = computed(
         'completedAmount',
         {
           key: 'completedAmount',
-          label: t('redemption_history.headers.hf_amount'),
+          label: t('redemption.history.headers.hf_amount'),
           description: hasPartialRedemption.value ? '*partial redemption' : '',
           isVisibleOnMobile: false,
           isSortable: true,
@@ -94,7 +94,7 @@ const headersMap = computed(
         'redemptionAmount',
         {
           key: 'redemptionAmount',
-          label: t('redemption_history.headers.redemption_amount'),
+          label: t('redemption.history.headers.redemption_amount'),
           isVisibleOnMobile: true,
           isSortable: true,
           align: 'end',
@@ -105,7 +105,7 @@ const headersMap = computed(
         'transactionId',
         {
           key: 'transactionId',
-          label: t('redemption_history.headers.transaction_id'),
+          label: t('redemption.history.headers.transaction_id'),
           isVisibleOnMobile: true,
           isSortable: true,
           type: 'string'
@@ -115,7 +115,7 @@ const headersMap = computed(
         'status',
         {
           key: 'status',
-          label: t('redemption_history.headers.status'),
+          label: t('redemption.history.headers.status'),
           isVisibleOnMobile: true,
           isSortable: true,
           type: 'string'
@@ -159,7 +159,7 @@ onMounted(async (): Promise<void> => {
         :headers="[...headersMap.values()]"
         initial-sort-by="createdDate"
         :items="redemptions"
-        empty-message-translation-key="redemption_history.errors.no_redemptions"
+        empty-message-translation-key="redemption.history.errors.no_redemptions"
         @try-again-clicked="getRedemptionHistory"
       >
         <RedemptionHistoryTableRow


### PR DESCRIPTION
This PR:
- adds a Confirmation Modal that is shown when the redemption is successfully initiated
<img width="751" alt="Screenshot 2023-04-28 at 13 45 00" src="https://user-images.githubusercontent.com/17565389/235139132-3fb62a49-229d-4973-8db7-1a9f4d50d946.png">

- hooks up API calls to "Confirm & Redeem" button that makes calls using zome_call:

1. `get_all_reserve_accounts_details` - to get the reserve details used in the second call
2. `redemption` - to initiate redemption 

- redirects to earnings when the redemption is successfully initiated

- checks redeemable amount just before making a call for redemption and returns to step one with an error message if the requested amount exceeds redeemable amount
<img width="1496" alt="Screenshot 2023-04-28 at 15 20 51" src="https://user-images.githubusercontent.com/17565389/235159604-ecb9a41c-faad-49bd-9306-103b5a1eb9c6.png">

- if redeem API call fails it returns to step one and shows the error banner
<img width="1501" alt="Screenshot 2023-04-28 at 15 19 43" src="https://user-images.githubusercontent.com/17565389/235159742-5f73c1a1-8dc3-4285-86e2-06f8162d3261.png">
