### PR TITLE
Fix/modals behaviour not to appear on every redirect

### DIFF
--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -10,8 +10,8 @@ export const kSortOptions = {
 }
 
 export enum EModal {
-  welcome,
-  redemption_initiated
+  welcome = 'welcome',
+  redemption_initiated = 'redemption_initiated'
 }
 
 export const kMsInSecond = 1000


### PR DESCRIPTION
This PR fixes modals behaviour that was caused by having two modal enums (one for host-console and one from the ui-common-library), both enums had value assigned to `0`. That caused both modals to appear at the same time. Now we use strings in host-console to distinguish app specific modals.