### PR TITLE
Feature/kyc level two

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import TheBanner from '@uicommon/components/TheBanner.vue'
 import TheOverlay from '@uicommon/components/TheOverlay.vue'
+import TheErrorModal from '@/components/ErrorModal.vue'
 </script>
 
 <template>
   <TheBanner />
   <TheOverlay />
+  <TheErrorModal />
   <router-view />
 </template>

--- a/src/components/BaseTooltip.vue
+++ b/src/components/BaseTooltip.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+defineProps<{
+  isVisible: boolean
+}>()
+</script>
+
+<template>
+  <Transition name="fade">
+    <div
+      v-if="isVisible"
+      class="holo-tooltip"
+    >
+      <slot />
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.holo-tooltip {
+  position: absolute;
+  z-index: 50;
+  right: 12px;
+  top: 20px;
+  background: var(--grey-color);
+  border-radius: 2px;
+  font-size: 14px;
+  line-height: 19px;
+  color: var(--white-color);
+  margin-top: 1px;
+  padding: 8px 12px;
+  cursor: pointer;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+}
+
+.holo-tooltip::before {
+  position: absolute;
+  right: 7px;
+  top: -5px;
+  content: '';
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 6px 6px 6px;
+  border-color: transparent transparent var(--grey-color) transparent;
+}
+
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease 0.5s;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/components/ErrorModal.vue
+++ b/src/components/ErrorModal.vue
@@ -1,0 +1,64 @@
+<script setup>
+import { ExclamationTriangleIcon } from '@heroicons/vue/20/solid'
+import { useModals } from '@uicommon/composables/useModals'
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import BaseModal from '@uicommon/components/BaseModal.vue'
+import { EModal } from '@/constants/ui'
+
+const { t } = useI18n()
+
+const title = ref('')
+const description = ref('')
+const { visibleModal, hideModal } = useModals()
+
+function close() {
+  hideModal()
+}
+</script>
+
+<template>
+  <BaseModal
+    :is-visible="visibleModal === EModal.error_modal"
+    @close="close"
+  >
+		<div class="error-modal">
+      <p class="error-modal__title">
+        <ExclamationTriangleIcon class="error-modal__icon" />
+        <span class="mt-4">{{ t('$.errors.unexpected') }}</span>
+      </p>
+      <div class="error-modal__description">
+        <p>We are sorry but something went wrong on our side.</p>
+        <p>
+          Please try again, and if the problem persists, contact our support at
+          <a href="mailto:help@holo.host?subject=Springboard support&body=">help@holo.host</a>.
+        </p>
+      </div>
+    </div>
+  </BaseModal>
+</template>
+
+<style scoped lang="scss">
+.error-modal {
+	&__title {
+		display: flex;
+		align-items: center;
+		margin-top: 6px;
+		font-size: 26px;
+		font-weight: 600;
+		text-align: center;
+	}
+
+	&__icon {
+		width: 50px;
+		height: 50px;
+		margin-right: 8px;
+		color: #F87171;
+	}
+
+	&__description {
+		margin-top: 40px;
+		padding: 0 46px;
+	}
+}
+</style>

--- a/src/components/TopNavMenu.vue
+++ b/src/components/TopNavMenu.vue
@@ -63,7 +63,7 @@ async function openSettingsAndCloseMenu(): Promise<void> {
         <div class="display-name">
           {{ nickname }}
           <span class="verification-status">
-            Unverified
+            {{ $t('settings.verification.verified') }}
           </span>
         </div>
         <DownTriangleIcon

--- a/src/components/dashboard/HoloFuelCard.vue
+++ b/src/components/dashboard/HoloFuelCard.vue
@@ -1,16 +1,19 @@
 <script setup lang="ts">
 import BaseCard from '@uicommon/components/BaseCard.vue'
 import { formatCurrency } from '@uicommon/utils/numbers'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
+import BaseTooltip from '@/components/BaseTooltip.vue'
+import RightArrowIcon from '@/components/icons/FatArrowIcon.vue'
 import router, { kRoutes } from '@/router'
 import { isError as isErrorPredicate } from '@/types/predicates'
-import type { DashboardCardItem } from '@/types/types'
+import type { DashboardCardItem, HoloFuelCardData, Error } from '@/types/types'
+import { EUserKycLevel } from '@/types/types'
 
 const { t } = useI18n()
 
 const props = defineProps<{
-  data: Data | { error: unknown }
+  data: HoloFuelCardData | Error
   isLoading: boolean
 }>()
 
@@ -18,12 +21,13 @@ const isError = computed((): boolean => isErrorPredicate(props.data) && !!props.
 
 const emit = defineEmits(['try-again-clicked'])
 
-interface Data {
-  available: string
-  redeemable: string
-}
+const isKycLevelOne = computed((): boolean => props.data.kycLevel === EUserKycLevel.one)
 
-const canRedeem = computed((): boolean => !isError.value && Number(props.data.redeemable) > 0)
+const canRedeem = computed(
+  (): boolean => !isError.value && !isKycLevelOne.value && Number(props.data.redeemable) > 0
+)
+
+const isRedeemHoloFuelTooltipVisible = ref(false)
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call */
 const items = computed((): DashboardCardItem[] => [
@@ -70,20 +74,38 @@ const items = computed((): DashboardCardItem[] => [
       </span>
     </div>
 
-    <button
-      :disabled="!canRedeem"
-      class="redeem-button"
-      @click="router.push({ name: kRoutes.redeemHoloFuel.name })"
+    <div
+      class="redeem-button-wrapper"
+      @mouseover="() => isKycLevelOne ? isRedeemHoloFuelTooltipVisible = true : null"
+      @mouseleave="() => isKycLevelOne ? isRedeemHoloFuelTooltipVisible = false: null"
+      @click="() => isKycLevelOne ? isRedeemHoloFuelTooltipVisible = true: null"
     >
-      {{ $t('holofuel.redeem_holofuel') }}
-    </button>
+      <button
+        :disabled="!canRedeem"
+        class="redeem-button"
+        @click="router.push({ name: kRoutes.redeemHoloFuel.name })"
+      >
+        {{ $t('holofuel.redeem_holofuel') }}
+      </button>
+
+      <BaseTooltip
+        class="redeem-button__tooltip"
+        :is-visible="isRedeemHoloFuelTooltipVisible"
+      >
+        {{ $t('redemption.redeem_holofuel.kyc_level_one_notice') }}
+      </BaseTooltip>
+    </div>
   </BaseCard>
 </template>
 
 <style scoped lang="scss">
+.redeem-button-wrapper {
+  position: relative;
+  align-self: center;
+}
+
 .redeem-button {
   margin-top: 10px;
-  align-self: center;
   border: none;
   color: white;
   font-size: 12px;
@@ -98,6 +120,12 @@ const items = computed((): DashboardCardItem[] => [
   &:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  &__tooltip {
+    top: 48px;
+    right: 55px;
+    width: 260px;
   }
 }
 

--- a/src/components/settings/SettingsHolofuelSection.vue
+++ b/src/components/settings/SettingsHolofuelSection.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import HoloFuelAddress from './HoloFuelAddress.vue'
 import SettingsRow from './SettingsRow.vue'
 import SettingsSection from './SettingsSection.vue'
 import LeaveSiteIcon from '@/components/icons/LeaveSiteIcon.vue'
 import { useGoToSpringboard } from '@/composables/useGoToSpringboard'
+import { EUserKycLevel } from '@/types/types'
 
 const { goToSpringboard } = useGoToSpringboard()
 
@@ -14,13 +16,15 @@ const props = withDefaults(
   defineProps<{
     nickname: string
     agentAddress?: Uint8Array | null
-    currentLevel?: number
+    kycLevel: number
   }>(),
   {
-    agentAddress: null,
-    currentLevel: 1
+    agentAddress: null
   }
 )
+
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers
+const currentLevel = computed((): number => (props.kycLevel === EUserKycLevel.one ? 1 : 2))
 </script>
 
 <template>
@@ -44,9 +48,9 @@ const props = withDefaults(
       :label="t('settings.verification.label')"
     >
       <div class="flex flex-col">
-        <span>{{ t('settings.verification.current_level', { level: props.currentLevel }) }}</span>
+        <span>{{ t('settings.verification.current_level', { level: currentLevel }) }}</span>
         <p class="verification__description">
-          {{ t('settings.verification.description') }}
+          {{ t('settings.verification.next_level_descriptions.two') }}
         </p>
         <p
           class="springboard-link"
@@ -54,7 +58,7 @@ const props = withDefaults(
         >
           <LeaveSiteIcon />
           <span class="holofuel-address__link-label">
-            {{ t('settings.verification.link', { level: props.currentLevel + 1 }) }}
+            {{ t('settings.verification.link', { level: currentLevel + 1 }) }}
           </span>
         </p>
       </div>

--- a/src/components/settings/SettingsHolofuelSection.vue
+++ b/src/components/settings/SettingsHolofuelSection.vue
@@ -49,10 +49,14 @@ const currentLevel = computed((): number => (props.kycLevel === EUserKycLevel.on
     >
       <div class="flex flex-col">
         <span>{{ t('settings.verification.current_level', { level: currentLevel }) }}</span>
-        <p class="verification__description">
+        <p
+          v-if="currentLevel === 1"
+          class="verification__description"
+        >
           {{ t('settings.verification.next_level_descriptions.two') }}
         </p>
         <p
+          v-if="currentLevel === 1"
           class="springboard-link"
           @click="goToSpringboard"
         >

--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -12,7 +12,8 @@ export const kSortOptions = {
 export enum EModal {
   welcome = 'welcome',
   redemption_initiated = 'redemption_initiated',
-  go_to_springboard = 'go_to_springboard'
+  go_to_springboard = 'go_to_springboard',
+  error_modal = 'error_modal'
 }
 
 export const kMsInSecond = 1000

--- a/src/interfaces/HposInterface.ts
+++ b/src/interfaces/HposInterface.ts
@@ -15,6 +15,7 @@ interface HposInterface {
   getHostPreferences: () => Promise<HostPreferencesResponse | { error: unknown }>
   checkAuth: (email: string, password: string, authToken: string) => Promise<CheckAuthResponse>
   getUser: () => Promise<User>
+  getKycLevel: () => Promise<unknown>
   getHposStatus: () => Promise<HPosStatus>
   updateHoloportName: (name: string) => Promise<void>
   getHoloFuelProfile: () => unknown
@@ -674,6 +675,30 @@ export function useHposInterface(): HposInterface {
     }
   }
 
+  async function getKycLevel(): Promise<CoreAppVersion> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      const data = await hposHolochainCall({
+        method: 'get',
+        path: '/kyc'
+      })
+
+      console.log(data)
+
+      // if (typeof coreAppVersion === 'string') {
+      //   localStorage.setItem(kCoreAppVersionLSKey, coreAppVersion)
+      // }
+      //
+      // // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // return { coreAppVersion }
+    } catch (error) {
+      // return {
+      //   coreAppVersion: null
+      // }
+    }
+  }
+
   async function redeemHoloFuel(
     payload: RedeemHoloFuelPayload
   ): Promise<RedemptionTransaction | boolean> {
@@ -741,6 +766,7 @@ export function useHposInterface(): HposInterface {
     getCoreAppVersion,
     getHostPreferences,
     redeemHoloFuel,
+    getKycLevel,
     HPOS_API_URL
   }
 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -146,6 +146,8 @@ export default {
         redemption_failed: 'Something went wrong, please try again.'
       },
       holo_fuel_amount: 'HF Amount',
+      kyc_level_one_notice:
+        "As a KYC Level 1 user, you can't reedem HoloFuel. Please complete KYC Level 2 verification first.",
       partial_redemption_terms:
         'Redemptions are processed first come, first serve. By checking this box, you accept a partial redemption if 1) there isn’t enough HOT in the reserve to fulfill your entire request or 2) the price surpasses the minimum you have chosen.',
       recipient_address_input_label: 'Recipient HOT Address',
@@ -174,8 +176,14 @@ export default {
       current_level: 'Verified to Level {level}',
       description:
         'Level 2 verification is required for transactions larger than ~10,000 GBP and other special uses of HoloFuel.',
+      holo_kyc_1: 'Level 1',
+      holo_kyc_2: 'Level 2',
       label: 'Verification',
-      link: 'Complete level {level} verification'
+      link: 'Complete level {level} verification',
+      next_level_descriptions: {
+        two: 'As a level 1 user, you are limited to <500 GBP of transactions per month. update your KYC to make more transactions.'
+      },
+      verified: 'Verified'
     }
   },
   sidebar: {

--- a/src/pages/DashboardPage.vue
+++ b/src/pages/DashboardPage.vue
@@ -9,12 +9,15 @@ import UsageCard from '@/components/dashboard/UsageCard.vue'
 import PrimaryLayout from '@/components/PrimaryLayout.vue'
 import { kRoutes } from '@/router'
 import { useDashboardStore } from '@/store/dashboard'
+import { useUserStore } from '@/store/user'
 import { isError } from '@/types/predicates'
+import type { HoloFuelCardData, Error } from '@/types/types'
 
 const kPaymentsToDisplay = 3
 
 const router = useRouter()
 const dashboardStore = useDashboardStore()
+const userStore = useUserStore()
 
 const isLoadingEarnings = ref(false)
 const isLoadingUsage = ref(false)
@@ -25,6 +28,18 @@ const holoFuel = computed(() =>
     ? dashboardStore.hostEarnings
     : dashboardStore.hostEarnings.holofuel
 )
+
+const holoFuelCardData = computed((): HoloFuelCardData | Error => {
+  if (isError(holoFuel.value)) {
+    return holoFuel.value
+  } else {
+    return {
+      available: holoFuel.value?.available ?? '0',
+      redeemable: holoFuel.value?.redeemable ?? '0',
+      kycLevel: userStore.kycLevel
+    }
+  }
+})
 
 const topHostedHapps = computed(() => dashboardStore.hostedHapps)
 
@@ -86,7 +101,7 @@ onMounted(async (): Promise<void> => {
 
       <HoloFuelCard
         :is-loading="isLoadingEarnings"
-        :data="holoFuel"
+        :data="holoFuelCardData"
         class="holofuel-card"
         data-test-dashboard-holo-fuel-card
         @try-again-clicked="getEarnings"

--- a/src/pages/EarningsPage.vue
+++ b/src/pages/EarningsPage.vue
@@ -5,9 +5,11 @@ import RedeemableHoloFuelCard from '@/components/earnings/RedeemableHoloFuelCard
 import WeeklyEarningsCard from '@/components/earnings/WeeklyEarningsCard.vue'
 import PrimaryLayout from '@/components/PrimaryLayout.vue'
 import { useDashboardStore } from '@/store/dashboard'
+import { useUserStore } from '@/store/user'
 import { isError as isErrorPredicate } from '@/types/predicates'
 
 const dashboardStore = useDashboardStore()
+const userStore = useUserStore()
 
 const isLoading = ref(false)
 const isError = computed(() => !!dashboardStore.hostEarnings.error)
@@ -26,6 +28,8 @@ const redeemableHoloFuel = computed((): number =>
     ? Number(dashboardStore.hostEarnings.holofuel.redeemable || 0)
     : 0
 )
+
+const kycLevel = computed(() => userStore.kycLevel)
 
 async function getEarnings(): Promise<void> {
   isLoading.value = true
@@ -55,7 +59,8 @@ onMounted(async (): Promise<void> => {
       />
 
       <RedeemableHoloFuelCard
-        :data="redeemableHoloFuel"
+        :redeemable-value="redeemableHoloFuel"
+        :kyc-level="kycLevel"
         :is-loading="false"
         :is-error="false"
         data-test-earnings-redeemable-holo-fuel-card

--- a/src/pages/SettingsPage.vue
+++ b/src/pages/SettingsPage.vue
@@ -23,6 +23,7 @@ async function onDeviceNameUpdate(deviceName: string): Promise<void> {
 
     <SettingsHolofuelSection
       :nickname="user.holoFuel.nickname"
+			:kyc-level="user.kycLevel"
       :agent-address="user.holoFuel.agentAddress"
       class="settings__holofuel-section"
     />

--- a/src/pages/SettingsPage.vue
+++ b/src/pages/SettingsPage.vue
@@ -23,7 +23,7 @@ async function onDeviceNameUpdate(deviceName: string): Promise<void> {
 
     <SettingsHolofuelSection
       :nickname="user.holoFuel.nickname"
-			:kyc-level="user.kycLevel"
+      :kyc-level="user.kycLevel"
       :agent-address="user.holoFuel.agentAddress"
       class="settings__holofuel-section"
     />

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -3,7 +3,7 @@ import { UpdateHoloFuelProfilePayload, useHposInterface } from '@/interfaces/Hpo
 import { isHoloFuelProfile } from '@/types/predicates'
 import type { HoloFuelProfile } from '@/types/types'
 
-const { getCoreAppVersion, getUser, updateHoloFuelProfile, updateHoloportName } = useHposInterface()
+const { getCoreAppVersion, getUser, updateHoloFuelProfile, updateHoloportName, getKycLevel } = useHposInterface()
 
 interface State {
   publicKey: string | undefined
@@ -36,6 +36,9 @@ export const useUserStore = defineStore('user', {
     async getUser(): Promise<void> {
       const { coreAppVersion } = await getCoreAppVersion()
       const getUserResponse = await getUser()
+      const kycLevel = await getKycLevel()
+
+      console.log('kycLevelResponse', kycLevel)
 
       if (getUserResponse.user && isHoloFuelProfile(getUserResponse.holoFuelProfile)) {
         const { user, holoport, holoFuelProfile } = getUserResponse

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,10 +1,10 @@
-import {useModals} from '@uicommon/composables/useModals.js'
-import {defineStore} from 'pinia'
-import {EModal} from '@/constants/ui'
-import {UpdateHoloFuelProfilePayload, useHposInterface} from '@/interfaces/HposInterface'
-import {isHoloFuelProfile} from '@/types/predicates'
-import type {HoloFuelProfile} from '@/types/types'
-import {EUserKycLevel} from '@/types/types'
+import { useModals } from '@uicommon/composables/useModals.js'
+import { defineStore } from 'pinia'
+import { EModal } from '@/constants/ui'
+import { UpdateHoloFuelProfilePayload, useHposInterface } from '@/interfaces/HposInterface'
+import { isHoloFuelProfile } from '@/types/predicates'
+import type { HoloFuelProfile } from '@/types/types'
+import { EUserKycLevel } from '@/types/types'
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
 const { showModal } = useModals()
@@ -58,7 +58,7 @@ export const useUserStore = defineStore('user', {
       }
 
       if (kycLevel) {
-        this.kycLevel = EUserKycLevel.two
+        this.kycLevel = kycLevel
       } else {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
         showModal(EModal.error_modal)

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,10 +1,10 @@
-import { useModals } from '@uicommon/composables/useModals.js'
-import { defineStore } from 'pinia'
-import { EModal } from '@/constants/ui'
-import { UpdateHoloFuelProfilePayload, useHposInterface } from '@/interfaces/HposInterface'
-import { isHoloFuelProfile } from '@/types/predicates'
-import type { HoloFuelProfile } from '@/types/types'
-import { EUserKycLevel } from '@/types/types'
+import {useModals} from '@uicommon/composables/useModals.js'
+import {defineStore} from 'pinia'
+import {EModal} from '@/constants/ui'
+import {UpdateHoloFuelProfilePayload, useHposInterface} from '@/interfaces/HposInterface'
+import {isHoloFuelProfile} from '@/types/predicates'
+import type {HoloFuelProfile} from '@/types/types'
+import {EUserKycLevel} from '@/types/types'
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
 const { showModal } = useModals()
@@ -21,7 +21,7 @@ interface State {
   hposVersion: string
   holoFuel: HoloFuelProfile
   coreAppVersion: string
-  kycLevel: string
+  kycLevel: EUserKycLevel
 }
 
 export const useUserStore = defineStore('user', {
@@ -58,7 +58,7 @@ export const useUserStore = defineStore('user', {
       }
 
       if (kycLevel) {
-        this.kycLevel = kycLevel
+        this.kycLevel = EUserKycLevel.two
       } else {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
         showModal(EModal.error_modal)

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,9 +1,16 @@
+import { useModals } from '@uicommon/composables/useModals.js'
 import { defineStore } from 'pinia'
+import { EModal } from '@/constants/ui'
 import { UpdateHoloFuelProfilePayload, useHposInterface } from '@/interfaces/HposInterface'
 import { isHoloFuelProfile } from '@/types/predicates'
 import type { HoloFuelProfile } from '@/types/types'
+import { EUserKycLevel } from '@/types/types'
 
-const { getCoreAppVersion, getUser, updateHoloFuelProfile, updateHoloportName, getKycLevel } = useHposInterface()
+// eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
+const { showModal } = useModals()
+
+const { getCoreAppVersion, getUser, updateHoloFuelProfile, updateHoloportName, getKycLevel } =
+  useHposInterface()
 
 interface State {
   publicKey: string | undefined
@@ -14,6 +21,7 @@ interface State {
   hposVersion: string
   holoFuel: HoloFuelProfile
   coreAppVersion: string
+  kycLevel: string
 }
 
 export const useUserStore = defineStore('user', {
@@ -29,7 +37,8 @@ export const useUserStore = defineStore('user', {
       nickname: '',
       avatarUrl: ''
     },
-    coreAppVersion: ''
+    coreAppVersion: '',
+    kycLevel: EUserKycLevel.one
   }),
 
   actions: {
@@ -37,8 +46,6 @@ export const useUserStore = defineStore('user', {
       const { coreAppVersion } = await getCoreAppVersion()
       const getUserResponse = await getUser()
       const kycLevel = await getKycLevel()
-
-      console.log('kycLevelResponse', kycLevel)
 
       if (getUserResponse.user && isHoloFuelProfile(getUserResponse.holoFuelProfile)) {
         const { user, holoport, holoFuelProfile } = getUserResponse
@@ -48,6 +55,13 @@ export const useUserStore = defineStore('user', {
         this.deviceName = holoport.name ?? ''
         this.hposVersion = holoport.hposVersion ?? ''
         this.holoFuel = holoFuelProfile
+      }
+
+      if (kycLevel) {
+        this.kycLevel = kycLevel
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
+        showModal(EModal.error_modal)
       }
 
       if (coreAppVersion) {

--- a/src/types/predicates.ts
+++ b/src/types/predicates.ts
@@ -1,5 +1,6 @@
 import type { HostPreferencesResponse, Redemption, Transaction } from '@/interfaces/HposInterface'
 import type { AdminSignature, CheckAuthResponse, Error, HoloFuelProfile } from '@/types/types'
+import { EUserKycLevel } from '@/types/types'
 
 export function isAdminSignature(target: CheckAuthResponse): target is AdminSignature {
   return target !== null
@@ -27,5 +28,9 @@ export function isTransactionsArray(target: unknown): target is Transaction[] {
 }
 
 export function isRedemptionsArray(target: unknown): target is Redemption[] {
+  return target !== undefined
+}
+
+export function isKycLevel(target: unknown): target is EUserKycLevel {
   return target !== undefined
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -68,3 +68,9 @@ export enum EUserKycLevel {
   one = 'holo_kyc_1',
   two = 'holo_kyc_2'
 }
+
+export interface HoloFuelCardData {
+  available: string | number
+  redeemable: string | number
+  kycLevel: EUserKycLevel
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -63,3 +63,8 @@ export interface DashboardCardItem {
   value: number
   isActive?: boolean
 }
+
+export enum EUserKycLevel {
+  one = 'holo_kyc_1',
+  two = 'holo_kyc_2'
+}


### PR DESCRIPTION
This PR:
- fetched user's current KYC level
- show proper KYC level in the settings
- disables redeem HoloFuel button when user is not on Level 2
- shows a tooltip is redeem HoloFuel button is disable and user is on Level 1

<img width="623" alt="Screenshot 2023-09-04 at 11 01 26" src="https://github.com/Holo-Host/host-console-ui/assets/17565389/4674319f-986b-4612-ab3d-7c74623034aa">
<img width="1494" alt="Screenshot 2023-09-04 at 11 11 30" src="https://github.com/Holo-Host/host-console-ui/assets/17565389/b8fe7f13-7d9a-4272-8cc4-1018b81f7ca3">
<img width="1488" alt="Screenshot 2023-09-04 at 11 14 09" src="https://github.com/Holo-Host/host-console-ui/assets/17565389/b2bc8d74-b48c-4903-8852-e273d62b9491">

