### PR TITLE
Feature(KYC): update disabled button tip content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "host-console",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "private": true,
   "homepage": "https://holo-host.github.io/host-console-ui/",
   "scripts": {

--- a/src/components/dashboard/HoloFuelCard.vue
+++ b/src/components/dashboard/HoloFuelCard.vue
@@ -5,12 +5,14 @@ import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import BaseTooltip from '@/components/BaseTooltip.vue'
 import RightArrowIcon from '@/components/icons/FatArrowIcon.vue'
+import { useGoToSpringboard } from '@/composables/useGoToSpringboard'
 import router, { kRoutes } from '@/router'
 import { isError as isErrorPredicate } from '@/types/predicates'
 import type { DashboardCardItem, HoloFuelCardData, Error } from '@/types/types'
 import { EUserKycLevel } from '@/types/types'
 
 const { t } = useI18n()
+const { goToSpringboard } = useGoToSpringboard()
 
 const props = defineProps<{
   data: HoloFuelCardData | Error
@@ -92,7 +94,13 @@ const items = computed((): DashboardCardItem[] => [
         class="redeem-button__tooltip"
         :is-visible="isRedeemHoloFuelTooltipVisible"
       >
-        {{ $t('redemption.redeem_holofuel.kyc_level_one_notice') }}
+        {{ $t('redemption.redeem_holofuel.kyc_level_one_notice_part_one') }}
+        <span
+          class="springboard-link"
+          @click="goToSpringboard"
+        >
+          {{ $t('redemption.redeem_holofuel.kyc_level_one_notice_part_two') }}
+        </span>
       </BaseTooltip>
     </div>
   </BaseCard>
@@ -131,5 +139,12 @@ const items = computed((): DashboardCardItem[] => [
 
 .margin-bottom {
   margin-bottom: 10px;
+}
+
+.springboard-link {
+  font-weight: bold;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 4px;
 }
 </style>

--- a/src/components/earnings/RedeemableHoloFuelCard.vue
+++ b/src/components/earnings/RedeemableHoloFuelCard.vue
@@ -9,12 +9,14 @@ import RightArrowIcon from '@/components/icons/FatArrowIcon.vue'
 import RedemptionHistoryIcon from '@/components/icons/RedemptionHistoryIcon.vue'
 import TransferIcon from '@/components/icons/TransferIcon.vue'
 import { useGoToHoloFuel } from '@/composables/useGoToHoloFuel'
+import { useGoToSpringboard } from '@/composables/useGoToSpringboard'
 import { kRoutes } from '@/router'
 import { EUserKycLevel } from '@/types/types'
 
 const emit = defineEmits(['try-again-clicked'])
 
 const { goToHoloFuel } = useGoToHoloFuel()
+const { goToSpringboard } = useGoToSpringboard()
 
 const props = defineProps<{
   redeemableValue: number
@@ -74,7 +76,13 @@ const canRedeem = computed((): boolean => !isKycLevelOne.value && Number(props.r
           class="redeemable-holofuel__redeem-button-tooltip"
           :is-visible="isRedeemHoloFuelTooltipVisible"
         >
-          {{ $t('redemption.redeem_holofuel.kyc_level_one_notice') }}
+          {{ $t('redemption.redeem_holofuel.kyc_level_one_notice_part_one') }}
+          <span
+            class="springboard-link"
+            @click="goToSpringboard"
+          >
+            {{ $t('redemption.redeem_holofuel.kyc_level_one_notice_part_two') }}
+          </span>
         </BaseTooltip>
       </div>
 
@@ -117,6 +125,13 @@ const canRedeem = computed((): boolean => !isKycLevelOne.value && Number(props.r
       width: 260px;
     }
   }
+}
+
+.springboard-link {
+  font-weight: bold;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 4px;
 }
 
 @media screen and (max-width: 1050px) {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -146,8 +146,8 @@ export default {
         redemption_failed: 'Something went wrong, please try again.'
       },
       holo_fuel_amount: 'HF Amount',
-      kyc_level_one_notice:
-        "As a KYC Level 1 user, you can't reedem HoloFuel. Please complete KYC Level 2 verification first.",
+      kyc_level_one_notice_part_one: 'Please complete your Level 2 KYC to redeem HoloFuel.',
+      kyc_level_one_notice_part_two: 'Upgrade to Level 2',
       partial_redemption_terms:
         'Redemptions are processed first come, first serve. By checking this box, you accept a partial redemption if 1) there isn’t enough HOT in the reserve to fulfill your entire request or 2) the price surpasses the minimum you have chosen.',
       recipient_address_input_label: 'Recipient HOT Address',


### PR DESCRIPTION
This PR updates the content of the disabled Reedem button tooltip to include link to Springbaord.

<img width="496" alt="Screenshot 2023-09-05 at 09 13 00" src="https://github.com/Holo-Host/host-console-ui/assets/17565389/3fca79b7-4a33-4d04-bae0-1806545d1b1a">
<img width="1213" alt="Screenshot 2023-09-05 at 09 13 11" src="https://github.com/Holo-Host/host-console-ui/assets/17565389/3e0c10f0-814b-416d-a689-977c00abc543">
