### PR TITLE
Host Console UI: Hosts can only enable hosting with KYC Level 2

### DIFF
--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -668,14 +668,6 @@ const data = {
         case 'get_default_happ_preferences':
           return mockDefaultHappPreferences
         case 'set_default_happ_preferences':
-          mockDefaultHappPreferences = {
-            max_fuel_before_invoice: '1000',
-            max_time_before_invoice: [2000, 500],
-            price_bandwidth: '0',
-            price_compute: '0.0001',
-            price_storage: '0'
-          }
-          
           return true
         case 'redeem':
           return redemptionTransaction

--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -219,6 +219,99 @@ const redemptionTransaction = {
     redemption: '0x12345678...'
   },}
 
+const mockHapps = [
+  {
+    id: 'ef48c978-3a34-42fc-a0b7-8ffa89f2bebb',
+    name: 'CoreApp',
+    enabled: true,
+    isPaused: false,
+    special_installed_app_id: coreAppVersion.version,
+  }
+]
+
+const mockHosts = [
+  {
+    "host_pub_key": "uhCAkokIsoB0_NuY_GbL4_xmVlwoWvnJJcvRTOwFvAAU1iCrWE7ck",
+    "holoport_id": "QuantumCoreServer",
+    "preferences": {
+      "timestamp": 1698953469075923,
+      "max_fuel_before_invoice": "1",
+      "price_compute": "75",
+      "price_storage": "75",
+      "price_bandwidth": "75",
+      "max_time_before_invoice": {
+        "secs": 18446744073709552000,
+        "nanos": 999999999
+      }
+    },
+    "preferences_hash": "uhCkkcbUz9JvKRn56E_c3IEaimnEYifLo2CbjavFrYYjYyqx05AI5"
+  },
+  {
+    "host_pub_key": "uhCAkokIsoB0_NuY_GbK6_xmVlwoWvnJJcvRTOwFvAAU1iCrWE7ck",
+    "holoport_id": "NimbusEdgeServer",
+    "preferences": {
+      "timestamp": 1698953469075923,
+      "max_fuel_before_invoice": "1",
+      "price_compute": "50",
+      "price_storage": "50",
+      "price_bandwidth": "50",
+      "max_time_before_invoice": {
+        "secs": 18446744073709552000,
+        "nanos": 999999999
+      }
+    },
+    "preferences_hash": "uhCkkcbUz9JvKRn56E_c3IEaimnEYifLo2CbjavFrYYjYyqx05AI5"
+  },
+  {
+    "host_pub_key": "uhCAkokIsoB0_NuY_GbJ7_xmVlwoWvnJJcvRTOwFvAAU1iCrWE7ck",
+    "holoport_id": "Happy PhoenixBlazeServer",
+    "preferences": {
+      "timestamp": 1698953469075923,
+      "max_fuel_before_invoice": "1",
+      "price_compute": "100",
+      "price_storage": "100",
+      "price_bandwidth": "100",
+      "max_time_before_invoice": {
+        "secs": 18446744073709552000,
+        "nanos": 999999999
+      }
+    },
+    "preferences_hash": "uhCkkcbUz9JvKRn56E_c3IEaimnEYifLo2CbjavFrYYjYyqx05AI5"
+  },
+  {
+    "host_pub_key": "uhCAkokIsoB0_NuY_GbI8_xmVlwoWvnJJcvRTOwFvAAU1iCrWE7ck",
+    "holoport_id": "ZenithPulseServer",
+    "preferences": {
+      "timestamp": 1698953469075923,
+      "max_fuel_before_invoice": "1",
+      "price_compute": "25",
+      "price_storage": "25",
+      "price_bandwidth": "25",
+      "max_time_before_invoice": {
+        "secs": 18446744073709552000,
+        "nanos": 999999999
+      }
+    },
+    "preferences_hash": "uhCkkcbUz9JvKRn56E_c3IEaimnEYifLo2CbjavFrYYjYyqx05AI5"
+  },
+  {
+    "host_pub_key": "uhCAkokIsoB0_NuY_GbH9_xmVlwoWvnJJcvRTOwFvAAU1iCrWE7ck",
+    "holoport_id": "NebulaSparkServer",
+    "preferences": {
+      "timestamp": 1698953469075923,
+      "max_fuel_before_invoice": "1",
+      "price_compute": "0",
+      "price_storage": "0",
+      "price_bandwidth": "0",
+      "max_time_before_invoice": {
+        "secs": 18446744073709552000,
+        "nanos": 999999999
+      }
+    },
+    "preferences_hash": "uhCkkcbUz9JvKRn56E_c3IEaimnEYifLo2CbjavFrYYjYyqx05AI5"
+  }        
+]
+
 const mockPaidInvoicesData = [
   {
     id: 'uhCEkuoMG0RpLkYciC3ZO2ZiedEhDq9yZJLrbjjVmNmXvjpvaAE6H',
@@ -547,13 +640,15 @@ const data = {
     '/api/v1/config': userConfig,
     '/api/v1/status': holoNixpkgs,
     '/holochain-api/v1/hosted_happs': happs,
+    '/holochain-api/v1/get_happs': mockHapps,
+    '/holochain-api/v1/get_hosts': mockHosts,
     '/holochain-api/v1/usage': usage,
     '/holochain-api/v1/host_earnings': earnings,
     '/holochain-api/v1/core_app_version': coreAppVersion,
     '/holochain-api/v1/host_invoices': mockPaidInvoicesData,
     '/holochain-api/v1/host_preferences': mockHostPreferences,
     '/holochain-api/v1/redemptions': mockRedemptionHistoryData,
-    '/holochain-api/v1/kyc': mockKycData
+    '/holochain-api/v1/kyc': mockKycData.kyc
   },
   put: {
     '/api/v1/config': (args) => args,

--- a/mock-hpos-api/defaultResponse.js
+++ b/mock-hpos-api/defaultResponse.js
@@ -631,7 +631,12 @@ const mockKycData = {
   "kyc": 'holo_kyc_2'
 }
 
-const mockHostPreferences = {
+let mockDefaultHappPreferences = {
+  max_fuel_before_invoice: '1000',
+  max_time_before_invoice: [2000, 500],
+  price_bandwidth: (Math.random() * 10).toFixed(5).toString(),
+  price_compute: (Math.random() * 10).toFixed(5).toString(),
+  price_storage: (Math.random() * 10).toFixed(5).toString()
 }
 
 // NB: both /api and /holochain-api calls are mocked here
@@ -646,7 +651,6 @@ const data = {
     '/holochain-api/v1/host_earnings': earnings,
     '/holochain-api/v1/core_app_version': coreAppVersion,
     '/holochain-api/v1/host_invoices': mockPaidInvoicesData,
-    '/holochain-api/v1/host_preferences': mockHostPreferences,
     '/holochain-api/v1/redemptions': mockRedemptionHistoryData,
     '/holochain-api/v1/kyc': mockKycData.kyc
   },
@@ -661,6 +665,18 @@ const data = {
           return getMyProfile
         case 'get_all_reserve_accounts_details':
           return getAllReserveAccountsDetails
+        case 'get_default_happ_preferences':
+          return mockDefaultHappPreferences
+        case 'set_default_happ_preferences':
+          mockDefaultHappPreferences = {
+            max_fuel_before_invoice: '1000',
+            max_time_before_invoice: [2000, 500],
+            price_bandwidth: '0',
+            price_compute: '0.0001',
+            price_storage: '0'
+          }
+          
+          return true
         case 'redeem':
           return redemptionTransaction
       }

--- a/src/components/settings/hostingPreferences/EditablePriceRow.vue
+++ b/src/components/settings/hostingPreferences/EditablePriceRow.vue
@@ -92,8 +92,6 @@ function cancel(): void {
 
   &__editable-value-input {
     width: 75px;
-    // margin-top: -8px;
-    // margin-left: -15px;
     margin-right: 30px;
   }
 
@@ -110,7 +108,6 @@ function cancel(): void {
   }
 
   &__button {
-    // margin-top: -8px;
     margin-left: 5px;
     cursor: pointer;
   }

--- a/src/components/settings/hostingPreferences/EditablePriceRow.vue
+++ b/src/components/settings/hostingPreferences/EditablePriceRow.vue
@@ -5,7 +5,6 @@ import { ref } from 'vue'
 import CircledExIcon from '../../icons/CircledExIcon.vue'
 import FilledCheckIcon from '../../icons/FilledCheckIcon.vue'
 import PencilIcon from '../../icons/PencilIcon.vue'
-import SettingsRow from '../SettingsRow.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -23,7 +22,7 @@ const props = withDefaults(
 const emit = defineEmits(['update:value'])
 
 const isEditing = ref(false)
-const editedValue = ref('')
+const editedValue = ref(props.value)
 
 function edit(): void {
   editedValue.value = `${props.value}`
@@ -36,49 +35,48 @@ function save(): void {
 }
 
 function cancel(): void {
+  editedValue.value = `${props.value}`
   isEditing.value = false
-  editedValue.value = ''
 }
 </script>
 
 <template>
-  <SettingsRow
-    :label="label"
-    :value="!isEditing ? props.value : ''"
-    grid-columns="110px auto"
-  >
-    <div
-      v-if="isEditing"
-      class="editable-price-row__editable-value"
-    >
+    <div class="editable-price-row__editable-value">
+      <span  class="editable-price-row__label">{{ label }}</span>
+      <span  v-if="!isEditing" class="editable-price-row__readonly_value">{{ editedValue }}</span>
       <BaseInput
+        v-if="isEditing"
         v-model="editedValue"
-        :input-type="EInputType.number"
+        :input-type="EInputType.text"
         placeholder=""
         name="edited-value"
         class="editable-price-row__editable-value-input"
       />
 
       <FilledCheckIcon
+        v-if="isEditing"
         class="editable-price-row__button"
         data-testid="save-button"
+        role="button"
         @click="save"
       />
 
       <CircledExIcon
+        v-if="isEditing"
         class="editable-price-row__button"
         data-testid="cancel-button"
+        role="button"
         @click="cancel"
       />
+      <span class="editable-price-row__unit">{{ props.unit }}</span>
+      <PencilIcon
+        v-if="!isEditing"
+        role="button"
+        class="editable-price-row__editable-value-icon"
+        :class="{ 'disabled': props.isDisabled }"
+        @click="edit"
+      />
     </div>
-    <span class="editable-price-row__unit">{{ props.unit }}</span>
-    <PencilIcon
-      v-if="!isEditing"
-      class="editable-price-row__editable-value-icon"
-      :class="{ 'disabled': props.isDisabled }"
-      @click="edit"
-    />
-  </SettingsRow>
 </template>
 
 <style lang="scss" scoped>
@@ -88,12 +86,14 @@ function cancel(): void {
   &__editable-value {
     display: flex;
     align-items: center;
+    margin-bottom: 16px;
+    height: 32px;
   }
 
   &__editable-value-input {
-    width: 60px;
-    margin-top: -8px;
-    margin-left: -15px;
+    width: 75px;
+    // margin-top: -8px;
+    // margin-left: -15px;
     margin-right: 30px;
   }
 
@@ -110,7 +110,7 @@ function cancel(): void {
   }
 
   &__button {
-    margin-top: -8px;
+    // margin-top: -8px;
     margin-left: 5px;
     cursor: pointer;
   }
@@ -119,6 +119,17 @@ function cancel(): void {
     margin-left: 30px;
     color: var(--grey-color);
     font-weight: 700;
+  }
+
+  &__label {
+    width: 100px;
+    margin-right: 16px;
+    color: var(--grey-color);
+    font-weight: 700;
+  }
+
+  &__readonly_value {
+    width: 75px;
   }
 }
 </style>

--- a/src/components/settings/hostingPreferences/PricesSection.vue
+++ b/src/components/settings/hostingPreferences/PricesSection.vue
@@ -14,7 +14,6 @@ const props = defineProps<{
 const emit = defineEmits(['update:price'])
 
 function updatePrice({ prop, value }: UpdatePricePayload): void {
-  console.log(`Prices section: updatePrice: ${prop} ${value}`)
   emit('update:price', { prop, value })
 }
 

--- a/src/components/settings/hostingPreferences/PricesSection.vue
+++ b/src/components/settings/hostingPreferences/PricesSection.vue
@@ -79,7 +79,7 @@ const prices = computed((): PriceItem[] => [
   },
   {
     label: t('$.data_transfer'),
-    value: props.data.bandwidth ? formatPrice(props.data.bandwidth).value : 0,
+    value: props.data.bandwidth || 0,
     unit: 'HF per Gb',
     prop: 'bandwidth',
     isDisabled: false

--- a/src/components/settings/hostingPreferences/PricesSection.vue
+++ b/src/components/settings/hostingPreferences/PricesSection.vue
@@ -22,45 +22,6 @@ interface FormattedPrice {
   unit: string
 }
 
-function formatPrice(pricePerByte: number): FormattedPrice {
-  if (isNaN(pricePerByte)) {
-    return {
-      value: '--',
-      unit: 'HF per GB'
-    }
-  }
-
-  if (pricePerByte === 0) {
-    return {
-      value: 0,
-      unit: 'HF per GB'
-    }
-  }
-
-  const k = 1024
-  const sizes = ['byte', 'kB', 'MB', 'GB', 'TB']
-
-  // eslint-disable-next-line no-magic-numbers,@typescript-eslint/no-magic-numbers
-  const zerosAfterDecimal = -Math.floor(Math.log(pricePerByte) / Math.log(10))
-
-  if (zerosAfterDecimal <= 0) {
-    return {
-      // eslint-disable-next-line no-magic-numbers
-      value: parseFloat(pricePerByte).toFixed(0),
-      unit: `HF per ${sizes[0]}`
-    }
-  }
-
-  // eslint-disable-next-line no-magic-numbers,@typescript-eslint/no-magic-numbers
-  const unitIndex = Math.floor(zerosAfterDecimal / 3)
-
-  return {
-    // eslint-disable-next-line no-magic-numbers,@typescript-eslint/no-magic-numbers
-    value: parseFloat((pricePerByte * Math.pow(k, unitIndex)).toFixed(3)),
-    unit: `HF per ${sizes[unitIndex]}`
-  }
-}
-
 interface PriceItem {
   label: string
   value: string | number
@@ -73,14 +34,14 @@ const prices = computed((): PriceItem[] => [
   {
     label: t('$.cpu'),
     value: props.data.cpu || 0,
-    unit: 'HF per hour',
+    unit: t('hosting_preferences.prices.hfpermin'),
     prop: 'cpu',
     isDisabled: false
   },
   {
     label: t('$.data_transfer'),
     value: props.data.bandwidth || 0,
-    unit: 'HF per Gb',
+    unit: t('hosting_preferences.prices.hfpergb'),
     prop: 'bandwidth',
     isDisabled: false
   }

--- a/src/components/settings/hostingPreferences/PricesSection.vue
+++ b/src/components/settings/hostingPreferences/PricesSection.vue
@@ -3,7 +3,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import SettingsSection from '../SettingsSection.vue'
 import HostingPreferencesEditablePriceRow from './EditablePriceRow.vue'
-import type { PricesData } from '@/types/types'
+import type { PricesData, UpdatePricePayload } from '@/types/types'
 
 const { t } = useI18n()
 
@@ -13,12 +13,8 @@ const props = defineProps<{
 
 const emit = defineEmits(['update:price'])
 
-interface UpdatePricePayload {
-  prop: string
-  value: number
-}
-
 function updatePrice({ prop, value }: UpdatePricePayload): void {
+  console.log(`Prices section: updatePrice: ${prop} ${value}`)
   emit('update:price', { prop, value })
 }
 
@@ -78,16 +74,16 @@ const prices = computed((): PriceItem[] => [
   {
     label: t('$.cpu'),
     value: props.data.cpu || 0,
-    unit: 'HF per min',
+    unit: 'HF per hour',
     prop: 'cpu',
-    isDisabled: true
+    isDisabled: false
   },
   {
     label: t('$.data_transfer'),
     value: props.data.bandwidth ? formatPrice(props.data.bandwidth).value : 0,
-    unit: props.data.bandwidth ? formatPrice(props.data.bandwidth).unit : '',
+    unit: 'HF per Gb',
     prop: 'bandwidth',
-    isDisabled: true
+    isDisabled: false
   }
 ])
 </script>

--- a/src/components/settings/hostingPreferences/TogglePaidHostingSection.vue
+++ b/src/components/settings/hostingPreferences/TogglePaidHostingSection.vue
@@ -15,7 +15,7 @@ const props = defineProps<{
   paidHostingEnabled: boolean
 }>()
 
-const paidHostingEnabled = ref(props.paidHostingEnabled)
+const paidHostingEnabled = ref(props.paidHostingEnabled && userStore.kycLevel === EUserKycLevel.two)
 
 const emit = defineEmits(['paid_hosting_toggled'])
 
@@ -42,6 +42,7 @@ const paidHostingToggled = (isToggledOn: boolean): void => {
             :labelToggledOff="$t('hosting_preferences.toggle_paid_hosting.disabled')"
             :isDisabled="userStore.kycLevel !== EUserKycLevel.two"
             @toggle="paidHostingToggled">
+            data-test-toggle-paid-hosting
         </ToggleSwitch>
     </div>
     <div v-if="userStore.kycLevel !== EUserKycLevel.one" class="hosting-invoice-info">

--- a/src/components/settings/hostingPreferences/TogglePaidHostingSection.vue
+++ b/src/components/settings/hostingPreferences/TogglePaidHostingSection.vue
@@ -4,10 +4,12 @@ import { useI18n } from 'vue-i18n'
 import SettingsSection from '../SettingsSection.vue'
 import ToggleSwitch from '@uicommon/components/ToggleSwitch.vue'
 import { useUserStore } from '@/store/user'
+import { useGoToSpringboard } from '@/composables/useGoToSpringboard'
 import { EUserKycLevel } from '@/types/types'
 
 const { t } = useI18n()
 const userStore = useUserStore()
+const { goToSpringboard } = useGoToSpringboard()
 const paidHostingEnabled = ref(false)
 
 const emit = defineEmits(['paid_hosting_toggled'])
@@ -26,7 +28,7 @@ const paidHostingToggled = (isToggledOn: boolean): void => {
     <div class="toggle-container">
         <div v-if="userStore.kycLevel !== EUserKycLevel.two" class="kyc-needed-container">
             <span class="kyc-needed-text">{{ $t('hosting_preferences.toggle_paid_hosting.kyc_needed_part_one') }}</span>
-            <span class="kyc-needed-text__dark-text">{{ $t('hosting_preferences.toggle_paid_hosting.kyc_needed_part_two') }}</span>
+            <span class="kyc-needed-text__spingboard-link" @click="goToSpringboard">{{ $t('hosting_preferences.toggle_paid_hosting.kyc_needed_part_two') }}</span>
             <span class="kyc-needed-text">{{ $t('hosting_preferences.toggle_paid_hosting.kyc_needed_part_three') }}</span>
         </div>
         <ToggleSwitch
@@ -86,9 +88,12 @@ const paidHostingToggled = (isToggledOn: boolean): void => {
     font-size: 12px;
     font-weight: 400;
 
-    &__dark-text {
+    &__spingboard-link {
         color: #313C59;
         font-weight: 600;
+        cursor: pointer;
+        text-decoration: underline;
+        text-underline-offset: 4px;
     }
   }
 

--- a/src/components/settings/hostingPreferences/TogglePaidHostingSection.vue
+++ b/src/components/settings/hostingPreferences/TogglePaidHostingSection.vue
@@ -10,7 +10,12 @@ import { EUserKycLevel } from '@/types/types'
 const { t } = useI18n()
 const userStore = useUserStore()
 const { goToSpringboard } = useGoToSpringboard()
-const paidHostingEnabled = ref(false)
+
+const props = defineProps<{
+  paidHostingEnabled: boolean
+}>()
+
+const paidHostingEnabled = ref(props.paidHostingEnabled)
 
 const emit = defineEmits(['paid_hosting_toggled'])
 

--- a/src/components/settings/hostingPreferences/TogglePaidHostingSection.vue
+++ b/src/components/settings/hostingPreferences/TogglePaidHostingSection.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import SettingsSection from '../SettingsSection.vue'
+import ToggleSwitch from '@uicommon/components/ToggleSwitch.vue'
+import { useUserStore } from '@/store/user'
+import { EUserKycLevel } from '@/types/types'
+
+const { t } = useI18n()
+const userStore = useUserStore()
+const paidHostingEnabled = ref(false)
+
+const emit = defineEmits(['paid_hosting_toggled'])
+
+const paidHostingToggled = (isToggledOn: boolean): void => {
+    paidHostingEnabled.value = isToggledOn
+    emit('paid_hosting_toggled', isToggledOn)
+}
+
+</script>
+
+<template>
+  <SettingsSection
+    :title="$t('hosting_preferences.toggle_paid_hosting.paid_hosting')"
+    class="toggle-paid-hosting-section">
+    <div class="toggle-container">
+        <div v-if="userStore.kycLevel !== EUserKycLevel.two" class="kyc-needed-container">
+            <span class="kyc-needed-text">{{ $t('hosting_preferences.toggle_paid_hosting.kyc_needed_part_one') }}</span>
+            <span class="kyc-needed-text__dark-text">{{ $t('hosting_preferences.toggle_paid_hosting.kyc_needed_part_two') }}</span>
+            <span class="kyc-needed-text">{{ $t('hosting_preferences.toggle_paid_hosting.kyc_needed_part_three') }}</span>
+        </div>
+        <ToggleSwitch
+            :toggleOn="paidHostingEnabled"
+            :labelToggledOn="$t('hosting_preferences.toggle_paid_hosting.enabled')"
+            :labelToggledOff="$t('hosting_preferences.toggle_paid_hosting.disabled')"
+            :isDisabled="userStore.kycLevel !== EUserKycLevel.two"
+            @toggle="paidHostingToggled">
+        </ToggleSwitch>
+    </div>
+    <div v-if="userStore.kycLevel !== EUserKycLevel.one" class="hosting-invoice-info">
+        {{ paidHostingEnabled ?
+            $t('hosting_preferences.toggle_paid_hosting.invoice_info_enabled') :
+            $t('hosting_preferences.toggle_paid_hosting.invoice_info_disabled') }}
+    </div>
+</SettingsSection>
+</template>
+
+<style lang="scss" scoped>
+.toggle-paid-hosting-section {
+  &__subtitle {
+    color: var(--grey-dark-color);
+    font-weight: 700;
+  }
+
+  &__prices {
+    margin-top: 24px;
+    margin-left: 40px;
+  }
+
+  &__price {
+    margin-top: 6px;
+  }
+
+  .toggle-container {
+    display: flex;
+    flex-direction: row;
+    padding: 10px 23px;
+    justify-content: flex-end;
+    gap: 16px;
+    width: 100%;
+  }
+
+  .kyc-needed-container {
+    display: inline-flex;
+    padding: 6px 10px;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    border-radius: 8px;
+    background: #FDEBEB;
+  }
+
+  .kyc-needed-text {
+    color: #ED3C3C;
+    text-align: right;
+    font-size: 12px;
+    font-weight: 400;
+
+    &__dark-text {
+        color: #313C59;
+        font-weight: 600;
+    }
+  }
+
+  .hosting-invoice-info {
+    display: inline-flex;
+    padding: 10px 23px;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    border-radius: 8px;
+    background: #F5F5F4;
+    color: #929CB7;
+    text-align: center;
+    font-size: 12px;
+    font-weight: 400;
+    line-height: normal;    
+    width: 100%;
+    margin-top: 16px;
+  }
+}
+</style>

--- a/src/interfaces/HposInterface.ts
+++ b/src/interfaces/HposInterface.ts
@@ -578,13 +578,13 @@ export function useHposInterface(): HposInterface {
     }
 
     try {
-      await hposHolochainCall({
+      const hostPreferences = await hposHolochainCall({
         method: 'post',
         path: '/zome_call',
         params
       })
 
-      return true
+      return hostPreferences
     } catch (error) {
       console.error('getHostPreferences encountered an error: ', error)
       return false

--- a/src/interfaces/HposInterface.ts
+++ b/src/interfaces/HposInterface.ts
@@ -15,6 +15,7 @@ interface HposInterface {
   getHAppDetails: (id: string) => Promise<HAppDetails | { error: unknown }>
   startHostingHApp: (id: string) => Promise<void | { error: unknown }>
   stopHostingHApp: (id: string) => Promise<void | { error: unknown }>
+  setDefaultHAppPreferences(preferences: DefaultPreferencesPayload): Promise<boolean>
   updateHAppHostingPlan: (payload: UpdateHAppHostingPlanPayload) => Promise<boolean>
   getHostEarnings: () => Promise<HostEarnings | { error: unknown }>
   getHostPreferences: () => Promise<HostPreferencesResponse | { error: unknown }>
@@ -114,6 +115,14 @@ export interface HostPreferencesResponse {
   price_bandwidth: string
   price_compute: string
   price_storage: string
+}
+
+export interface DefaultPreferencesPayload {
+  max_fuel_before_invoice: string
+  price_compute: string
+  price_storage: string  
+  price_bandwidth: string
+  max_time_before_invoice: [number, number]
 }
 
 type HposHolochainCallResponse =
@@ -481,6 +490,28 @@ export function useHposInterface(): HposInterface {
     } catch (error) {
       console.error('stopHostingHApp encountered an error: ', error)
       return { error }
+    }
+  }
+
+  async function setDefaultHAppPreferences(preferences: DefaultPreferencesPayload): Promise<boolean> {
+    try {
+      const params = {
+        appId: localStorage.getItem(kCoreAppVersionLSKey),
+        roleId: 'core-app',
+        zomeName: 'hha',
+        fnName: 'set_default_happ_preferences',
+        payload: preferences
+      }
+
+      await hposHolochainCall({
+        method: 'post',
+        path: '/zome_call',
+        params
+      })
+
+      return true      
+    } catch (error) {
+      return false
     }
   }
 
@@ -863,6 +894,7 @@ export function useHposInterface(): HposInterface {
     redeemHoloFuel,
     getKycLevel,
     getHAppDetails,
+    setDefaultHAppPreferences,
     startHostingHApp,
     stopHostingHApp,
     updateHAppHostingPlan,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -157,6 +157,16 @@ export default {
     prices: {
       header: 'Price Configuration',
       subheader: 'Default Rates'
+    },
+    toggle_paid_hosting: {
+      paid_hosting: 'Paid Hosting',
+      kyc_needed_part_one: 'Please complete',
+      kyc_needed_part_two: 'KYC 2 verification',
+      kyc_needed_part_three: 'to get paid to host hApps.',
+      enabled: 'Enabled',
+      disabled: 'Disabled',
+      invoice_info_enabled: 'Invoices will be sent to hApp managers for hosting services provided unless free hosting is enabled for individual hApps.',
+      invoice_info_disabled: 'You are currently hosting hApps for free, switch the toggle on to start getting paid. If you would like to continue hosting any individual hApps for free, please toggle “free hosting” on for each individual hApp.'
     }
   },
   invoices: {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -156,7 +156,9 @@ export default {
     },
     prices: {
       header: 'Price Configuration',
-      subheader: 'Default Rates'
+      subheader: 'Default Rates',
+      hfpermin: 'HF per min',
+      hfpergb: 'HF per GB',
     },
     toggle_paid_hosting: {
       paid_hosting: 'Paid Hosting',

--- a/src/pages/HostingPreferences.vue
+++ b/src/pages/HostingPreferences.vue
@@ -50,9 +50,7 @@ async function setDefaultHostPreferences(): Promise<void> {
 }
 
 onMounted(async (): Promise<void> => {
-  if (!preferencesStore.isLoaded) {
     await getHostPreferences()
-  }
 })
 
 async function updatePrice({ prop, value }: UpdatePricePayload): Promise<void> {

--- a/src/pages/HostingPreferences.vue
+++ b/src/pages/HostingPreferences.vue
@@ -84,6 +84,7 @@ function onTogglePaidHosting(isToggledOn: boolean): void {
       <TogglePaidHostingSection
         :paidHostingEnabled="isPaidHostingEnabled"
         @paid_hosting_toggled="onTogglePaidHosting"
+        data-test-toggle-paid-hosting-section
       />    
       <PricesSection
         v-if="isPaidHostingEnabled"

--- a/src/pages/HostingPreferences.vue
+++ b/src/pages/HostingPreferences.vue
@@ -6,10 +6,12 @@ import InvoicesSection from '@/components/settings/hostingPreferences/InvoicesSe
 import PricesSection from '@/components/settings/hostingPreferences/PricesSection.vue'
 import TogglePaidHostingSection from '@/components/settings/hostingPreferences/TogglePaidHostingSection.vue'
 import { usePreferencesStore } from '@/store/preferences'
-import { useHposInterface } from '@/interfaces/HposInterface'
+import { useUserStore } from '@/store/user'
+import { EUserKycLevel } from '@/types/types'
 import type { UpdatePricePayload } from '@/types/types'
 
 const preferencesStore = usePreferencesStore()
+const userStore = useUserStore()
 
 const isLoading = ref(false)
 const isError = ref(false)
@@ -48,7 +50,9 @@ async function setDefaultHostPreferences(): Promise<void> {
 }
 
 onMounted(async (): Promise<void> => {
-  if (!preferencesStore.isLoaded) {
+  if( userStore.kycLevel !== EUserKycLevel.two) {
+    isPaidHostingEnabled.value = false
+  } else if (!preferencesStore.isLoaded) {
     await getHostPreferences()
   }
 })

--- a/src/pages/HostingPreferences.vue
+++ b/src/pages/HostingPreferences.vue
@@ -15,7 +15,7 @@ const userStore = useUserStore()
 
 const isLoading = ref(false)
 const isError = ref(false)
-const isPaidHostingEnabled = ref(false)
+const isPaidHostingEnabled = ref(userStore.kycLevel !== EUserKycLevel.two)
 
 const pricesSettings = computed(() => preferencesStore.pricesSettings)
 const invoicesSettings = computed(() => preferencesStore.invoicesSettings)
@@ -50,9 +50,7 @@ async function setDefaultHostPreferences(): Promise<void> {
 }
 
 onMounted(async (): Promise<void> => {
-  if( userStore.kycLevel !== EUserKycLevel.two) {
-    isPaidHostingEnabled.value = false
-  } else if (!preferencesStore.isLoaded) {
+  if (!preferencesStore.isLoaded) {
     await getHostPreferences()
   }
 })

--- a/src/pages/HostingPreferences.vue
+++ b/src/pages/HostingPreferences.vue
@@ -75,6 +75,7 @@ function updatePrice({ prop, value }: UpdatePricePayload): void {
       />
 
       <InvoicesSection
+        v-if="isPaidHostingEnabled"
         :data="invoicesSettings"
         class="hosting-preferences__invoices"
         data-test-hosting-preferences-invoices-section

--- a/src/pages/HostingPreferences.vue
+++ b/src/pages/HostingPreferences.vue
@@ -55,8 +55,7 @@ onMounted(async (): Promise<void> => {
 
 async function updatePrice({ prop, value }: UpdatePricePayload): Promise<void> {
   await preferencesStore.updatePrice(prop, value)
-  await preferencesStore.setDefaultPreferences()
-  await getHostPreferences()
+  await setDefaultHostPreferences()
 }
 
 function onTogglePaidHosting(isToggledOn: boolean): void {

--- a/src/pages/__tests__/HostingPreferences.test.js
+++ b/src/pages/__tests__/HostingPreferences.test.js
@@ -57,12 +57,16 @@ describe('hosting preferences page', () => {
       expect(wrapper.findAll('[data-test-hosting-preferences-layout]')).toHaveLength(1)
     })
 
-    it('with prices section', () => {
-      expect(wrapper.findAll('[data-test-hosting-preferences-prices-section]')).toHaveLength(1)
+    it('with toggle paid hosting section', () => {
+      expect(wrapper.findAll('[data-test-toggle-paid-hosting-section]')).toHaveLength(1)
+    })
+        
+    it('without prices section when paid hosting toggled off', () => {
+      expect(wrapper.findAll('[data-test-hosting-preferences-prices-section]')).toHaveLength(0)
     })
 
-    it('with invoices section', () => {
-      expect(wrapper.findAll('[data-test-hosting-preferences-invoices-section]')).toHaveLength(1)
+    it('without invoices section when paid hosting toggled off', () => {
+      expect(wrapper.findAll('[data-test-hosting-preferences-invoices-section]')).toHaveLength(0)
     })
 
     it('with happ selection section', () => {

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -4,6 +4,7 @@ import { isHostPreferencesResponse } from '@/types/predicates'
 import type { InvoicesData, PricesData } from '@/types/types'
 
 const { getHostPreferences, setDefaultHAppPreferences } = useHposInterface()
+const kInitialPrice = 0.0001
 
 interface State {
   isLoaded: boolean
@@ -44,9 +45,9 @@ export const usePreferencesStore = defineStore('preferences', {
     },
     setInitialPricing(): void {
       this.pricesSettings = {
-        cpu: 0.0001,
-        storage: 0.0001,
-        bandwidth: 0.0001
+        cpu: kInitialPrice,
+        storage: 0,
+        bandwidth: kInitialPrice
       }
     },
     clearPricing(): void {

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -42,6 +42,29 @@ export const usePreferencesStore = defineStore('preferences', {
 
       await setDefaultHAppPreferences(payload)
     },
+    setInitialPricing(): void {
+      this.pricesSettings = {
+        cpu: 0.0001,
+        storage: 0.0001,
+        bandwidth: 0.0001
+      }
+    },
+    clearPricing(): void {
+      this.pricesSettings = {
+        cpu: 0,
+        storage: 0,
+        bandwidth: 0
+      }
+    },
+    updatePrice(priceSetting: string, value: number): void {
+      if (priceSetting === 'cpu') {
+        this.pricesSettings.cpu = value
+      } else if (priceSetting === 'storage') {
+        this.pricesSettings.storage = value
+      } else if (priceSetting === 'bandwidth') {
+        this.pricesSettings.bandwidth = value
+      }
+    },   
     async getHostPreferences(): Promise<void> {
       const response = await getHostPreferences()
 

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -1,9 +1,9 @@
 import { defineStore } from 'pinia'
-import { useHposInterface } from '@/interfaces/HposInterface'
+import { useHposInterface, DefaultPreferencesPayload } from '@/interfaces/HposInterface'
 import { isHostPreferencesResponse } from '@/types/predicates'
 import type { InvoicesData, PricesData } from '@/types/types'
 
-const { getHostPreferences } = useHposInterface()
+const { getHostPreferences, setDefaultHAppPreferences } = useHposInterface()
 
 interface State {
   isLoaded: boolean
@@ -31,6 +31,17 @@ export const usePreferencesStore = defineStore('preferences', {
   }),
 
   actions: {
+    async setDefaultPreferences(): Promise<void> {
+      const payload: DefaultPreferencesPayload = {
+        max_fuel_before_invoice: `0`,
+        max_time_before_invoice: [0,0],
+        price_compute: `${this.pricesSettings.cpu}`,
+        price_storage: `${this.pricesSettings.storage}`,
+        price_bandwidth: `${this.pricesSettings.bandwidth}`
+      }
+
+      await setDefaultHAppPreferences(payload)
+    },
     async getHostPreferences(): Promise<void> {
       const response = await getHostPreferences()
 

--- a/src/store/preferences.ts
+++ b/src/store/preferences.ts
@@ -59,11 +59,11 @@ export const usePreferencesStore = defineStore('preferences', {
     },
     updatePrice(priceSetting: string, value: number): void {
       if (priceSetting === 'cpu') {
-        this.pricesSettings.cpu = value
+        this.pricesSettings.cpu = value > 0 ? value : 0
       } else if (priceSetting === 'storage') {
-        this.pricesSettings.storage = value
+        this.pricesSettings.storage = value > 0 ? value : 0
       } else if (priceSetting === 'bandwidth') {
-        this.pricesSettings.bandwidth = value
+        this.pricesSettings.bandwidth = value > 0 ? value : 0
       }
     },   
     async getHostPreferences(): Promise<void> {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -74,3 +74,8 @@ export interface HoloFuelCardData {
   redeemable: string | number
   kycLevel: EUserKycLevel
 }
+
+export interface UpdatePricePayload {
+  prop: string
+  value: number
+}


### PR DESCRIPTION
[Ticket in Agility](https://www51.v1host.com/Holo/story.mvc/Summary?oidToken=Story%3A80817)

- Paid hosting toggle is disabled if user is kyc level 1
- A message is displayed how to enable pricing with a link to springboard if the user is kyc level 1
- Host pricing and invoicing settings are hidden if user is kyc level 1 or paid hosting is disabled

![image](https://github.com/Holo-Host/host-console-ui/assets/16830873/8f0b00c5-0ac5-4644-ac7e-364dc49cecc1)

- Paid hosting toggle is enabled if user is kyc level 2
- Host pricing and invoicing settings are hidden if paid hosting is disabled
- User is shown a message that they are hosting apps for free if kyc level 2 and hosting is disabled

![image](https://github.com/Holo-Host/host-console-ui/assets/16830873/a630625a-9bb8-4f8a-ae45-37c86a4a382d)

- When pricing is toggled on the default pricing for cpu, bandwidth, and storage defaults to 0.0001 HF
- A message is displayed that hApp managers will receive invoices

![image](https://github.com/Holo-Host/host-console-ui/assets/16830873/58eefc45-026a-4d35-b548-424940238555)

- User's can edit pricing
- Clicking green check saves pricing setting
- Clinking X restores previous setting
- If All pricing is set to zero paid hosting toggle is toggled off

![image](https://github.com/Holo-Host/host-console-ui/assets/16830873/27a84640-893d-40c1-b679-315f7d8045ec)



