### PR TITLE
Fix/do not show welcome modal if nickname exist

### DIFF
--- a/src/components/PrimaryLayout.vue
+++ b/src/components/PrimaryLayout.vue
@@ -72,6 +72,11 @@ onMounted(async () => {
 
       try {
         await userStore.getUser()
+
+        if (!userStore.holoFuel.nickname) {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+          showModal(EModal.welcome)
+        }
       } catch (e) {
         localStorage.removeItem(kAuthTokenLSKey)
         await router.push({ name: kRoutes.login.name })
@@ -80,14 +85,12 @@ onMounted(async () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
       hideOverlay()
       isLoading.value = false
-    }
-
-    await nextTick(() => {
+    } else {
       if (!userStore.holoFuel.nickname) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         showModal(EModal.welcome)
       }
-    })
+    }
   })
 })
 </script>


### PR DESCRIPTION
Reproduction:
This issue was happening when user logged in to the same hp on a different browser. That results in the previous session being invalidated. When user refreshes the app, it logs him out. Trying to log in on the SAME session (no refresh anymore) results in welcome modal being shown.