### PR TITLE
Fix/block hosting toggle when paid hosting is enabled

### DIFF
--- a/src/components/settings/hostingPreferences/TogglePaidHostingSection.vue
+++ b/src/components/settings/hostingPreferences/TogglePaidHostingSection.vue
@@ -50,6 +50,8 @@ const paidHostingToggled = (isToggledOn: boolean): void => {
         :toggle-on="props.paidHostingEnabled"
         :label-toggled-on="t('hosting_preferences.toggle_paid_hosting.enabled')"
         :label-toggled-off="t('hosting_preferences.toggle_paid_hosting.disabled')"
+        :is-disabled="userStore.kycLevel !== EUserKycLevel.two"
+        :class="{ 'toggle-paid-hosting-section__is-disabled': props.paidHostingEnabled }"
         @toggle="paidHostingToggled"
       >
         data-test-toggle-paid-hosting


### PR DESCRIPTION
This PR:

- reverts a change that caused a regression that allows to switch back to free hosting