### PR TITLE
add `hp_id` param for happ enable/disable call

### DIFF
--- a/src/components/PrimaryLayout.vue
+++ b/src/components/PrimaryLayout.vue
@@ -64,7 +64,7 @@ onMounted(async () => {
   // we need to fetch user data again.
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   await nextTick(async (): Promise<void> => {
-    if (!userStore.publicKey) {
+    if (!(userStore.publicKey && userStore.holoportId)) {
       isLoading.value = true
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call

--- a/src/components/StopHostingModal.vue
+++ b/src/components/StopHostingModal.vue
@@ -3,15 +3,16 @@ import { ExclamationCircleIcon, CheckCircleIcon } from '@heroicons/vue/24/outlin
 import BaseButton from '@uicommon/components/BaseButton'
 import BaseModal from '@uicommon/components/BaseModal'
 import { useModals } from '@uicommon/composables/useModals'
-import { EButtonType } from '@uicommon/types/ui'
 import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { EModal } from '@/constants/ui'
+import { useUserStore } from '@/store/user'
 import { HAppDetails, useHposInterface } from '@/interfaces/HposInterface'
 import { isError as isErrorPredicate } from '@/types/predicates'
 
 const { t } = useI18n()
 const { stopHostingHApp, startHostingHApp } = useHposInterface()
+const userStore = useUserStore()
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
 const { showModal } = useModals()
@@ -31,9 +32,9 @@ async function confirm(): Promise<void> {
   let result = null
 
   if (props.hApp.enabled) {
-    result = await stopHostingHApp(props.hApp.id)
+    result = await stopHostingHApp(props.hApp.id, userStore.holoportId)
   } else {
-    result = await startHostingHApp(props.hApp.id)
+    result = await startHostingHApp(props.hApp.id, userStore.holoportId)
   }
 
   // If failed

--- a/src/interfaces/HposInterface.ts
+++ b/src/interfaces/HposInterface.ts
@@ -15,8 +15,8 @@ interface HposInterface {
   getUsage: () => Promise<UsageResponse | { error: unknown }>
   getHostedHApps: () => Promise<HApp[] | { error: unknown }>
   getHAppDetails: (id: string) => Promise<HAppDetails | { error: unknown }>
-  startHostingHApp: (id: string) => Promise<void | { error: unknown }>
-  stopHostingHApp: (id: string) => Promise<void | { error: unknown }>
+  startHostingHApp: (id: string, hpId: string) => Promise<void | { error: unknown }>
+  stopHostingHApp: (id: string, hpId: string) => Promise<void | { error: unknown }>
   setDefaultHAppPreferences: (preferences: DefaultPreferencesPayload) => Promise<boolean>
   updateHAppHostingPlan: (payload: UpdateHAppHostingPlanPayload) => Promise<boolean>
   getHostEarnings: () => Promise<HostEarnings | { error: unknown }>
@@ -476,13 +476,14 @@ export function useHposInterface(): HposInterface {
   }
 
   async function startHostingHApp(
-    id: string
+    id: string,
+    hpId: string
   ): Promise<HposHolochainCallResponse | { error: unknown }> {
     try {
       const result = await hposHolochainCall({
         method: 'post',
         pathPrefix: '/api/v2',
-        path: `/hosted_happs/${id}/enable`
+        path: `/hosted_happs/${id}/${hpId}enable`
       })
 
       return result
@@ -493,13 +494,14 @@ export function useHposInterface(): HposInterface {
   }
 
   async function stopHostingHApp(
-    id: string
+    id: string,
+    hpId: string
   ): Promise<HposHolochainCallResponse | { error: unknown }> {
     try {
       const result = await hposHolochainCall({
         method: 'post',
         pathPrefix: '/api/v2',
-        path: `/hosted_happs/${id}/disable`
+        path: `/hosted_happs/${id}/${hpId}enable`
       })
 
       return result

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -13,6 +13,7 @@ const { getCoreAppVersion, getUser, updateHoloFuelProfile, updateHoloportName, g
   useHposInterface()
 
 interface State {
+  holoportId: string | undefined,
   publicKey: string | undefined
   email: string
   networkFlavour: string
@@ -26,6 +27,7 @@ interface State {
 
 export const useUserStore = defineStore('user', {
   state: (): State => ({
+    holoportId: undefined,
     publicKey: undefined,
     email: '',
     networkFlavour: '',
@@ -67,6 +69,9 @@ export const useUserStore = defineStore('user', {
       if (coreAppVersion) {
         this.coreAppVersion = coreAppVersion
       }
+
+      const hostUrl = window.location.host;
+      this.holoportId = hostUrl.split(".")[0]
     },
 
     async updateHoloFuelProfile({


### PR DESCRIPTION
#### Context: We need to pass in the host pubkey from host console to ensure that we're referencing the correct pubkey in all envs - including dev.

### Updates:
 - fetches host pubkey from `location.host` and saves to user state
 - adds host pubkey (`hp_id`) param to enable happ and disable happ calls